### PR TITLE
Remove lockoutTime from base protocol

### DIFF
--- a/contracts/short/ShortSell.sol
+++ b/contracts/short/ShortSell.sol
@@ -128,9 +128,8 @@ contract ShortSell is
      *
      * @param  values32  Values corresponding to:
      *
-     *  [0] = loan lockout time     (in seconds)
-     *  [1] = loan call time limit  (in seconds)
-     *  [2] = loan maxDuration      (in seconds)
+     *  [0] = loan call time limit  (in seconds)
+     *  [1] = loan maxDuration      (in seconds)
      *
      * @param  sigV       ECDSA v parameters for [0] loan and [1] buy order
      * @param  sigRS      CDSA r and s parameters for [0] loan and [2] buy order
@@ -139,7 +138,7 @@ contract ShortSell is
     function short(
         address[13] addresses,
         uint[17] values256,
-        uint32[3] values32,
+        uint32[2] values32,
         uint8[2] sigV,
         bytes32[4] sigRS
     )
@@ -391,9 +390,8 @@ contract ShortSell is
      *
      * @param  values32         Values corresponding to:
      *
-     *  [0] = loan lockout time     (in seconds)
-     *  [1] = loan call time limit  (in seconds)
-     *  [2] = loan maxDuration      (in seconds)
+     *  [0] = loan call time limit  (in seconds)
+     *  [1] = loan maxDuration      (in seconds)
      *
      * @param  cancelAmount     Amount to cancel
      * @return _cancelledAmount Amount that was cancelled
@@ -401,7 +399,7 @@ contract ShortSell is
     function cancelLoanOffering(
         address[8] addresses,
         uint[9] values256,
-        uint32[3] values32,
+        uint32[2] values32,
         uint cancelAmount
     )
         external

--- a/contracts/short/ShortSellRepo.sol
+++ b/contracts/short/ShortSellRepo.sol
@@ -42,7 +42,6 @@ contract ShortSellRepo is StaticAccessControlled, NoOwner {
         uint shortAmount,
         uint interestRate,
         uint32 callTimeLimit,
-        uint32 lockoutTime,
         uint32 startTimestamp,
         uint32 maxDuration,
         address lender,
@@ -61,7 +60,6 @@ contract ShortSellRepo is StaticAccessControlled, NoOwner {
             closedAmount: 0,
             interestRate: interestRate,
             callTimeLimit: callTimeLimit,
-            lockoutTime: lockoutTime,
             startTimestamp: startTimestamp,
             callTimestamp: 0,
             maxDuration: maxDuration,
@@ -152,7 +150,6 @@ contract ShortSellRepo is StaticAccessControlled, NoOwner {
             uint closedAmount,
             uint interestRate,
             uint32 callTimeLimit,
-            uint32 lockoutTime,
             uint32 startTimestamp,
             uint32 callTimestamp,
             uint32 maxDuration,
@@ -169,7 +166,6 @@ contract ShortSellRepo is StaticAccessControlled, NoOwner {
             short.closedAmount,
             short.interestRate,
             short.callTimeLimit,
-            short.lockoutTime,
             short.startTimestamp,
             short.callTimestamp,
             short.maxDuration,
@@ -276,16 +272,6 @@ contract ShortSellRepo is StaticAccessControlled, NoOwner {
         returns (uint32 _callTimeLimit)
     {
         return shorts[id].callTimeLimit;
-    }
-
-    function getShortLockoutTime(
-        bytes32 id
-    )
-        view
-        external
-        returns (uint32 _lockoutTime)
-    {
-        return shorts[id].lockoutTime;
     }
 
     function getShortMaxDuration(

--- a/contracts/short/impl/LoanImpl.sol
+++ b/contracts/short/impl/LoanImpl.sol
@@ -68,7 +68,6 @@ library LoanImpl {
     {
         ShortSellCommon.Short memory short = ShortSellCommon.getShortObject(state.REPO, shortId);
         require(msg.sender == short.lender);
-        require(block.timestamp >= uint(short.startTimestamp).add(short.lockoutTime));
         // Ensure the loan has not already been called
         require(short.callTimestamp == 0);
         require(
@@ -116,7 +115,7 @@ library LoanImpl {
         ShortSellState.State storage state,
         address[8] addresses,
         uint[9] values256,
-        uint32[3] values32,
+        uint32[2] values32,
         uint cancelAmount
     )
         public
@@ -159,7 +158,7 @@ library LoanImpl {
     function parseLoanOffering(
         address[8] addresses,
         uint[9] values,
-        uint32[3] values32
+        uint32[2] values32
     )
         internal
         view
@@ -174,9 +173,8 @@ library LoanImpl {
             takerFeeToken: addresses[7],
             rates: parseLoanOfferRates(values),
             expirationTimestamp: values[7],
-            lockoutTime: values32[0],
-            callTimeLimit: values32[1],
-            maxDuration: values32[2],
+            callTimeLimit: values32[0],
+            maxDuration: values32[1],
             salt: values[8],
             loanHash: 0,
             signature: ShortSellCommon.Signature({

--- a/contracts/short/impl/ShortImpl.sol
+++ b/contracts/short/impl/ShortImpl.sol
@@ -39,7 +39,6 @@ library ShortImpl {
         uint shortAmount,
         uint baseTokenFromSell,
         uint depositAmount,
-        uint32 lockoutTime,
         uint32 callTimeLimit,
         uint32 maxDuration
     );
@@ -80,7 +79,7 @@ library ShortImpl {
         ShortSellState.State storage state,
         address[13] addresses,
         uint[17] values256,
-        uint32[3] values32,
+        uint32[2] values32,
         uint8[2] sigV,
         bytes32[4] sigRS
     )
@@ -124,7 +123,6 @@ library ShortImpl {
             transaction.shortAmount,
             getPartialInterestFee(transaction),
             transaction.loanOffering.callTimeLimit,
-            transaction.loanOffering.lockoutTime,
             uint32(block.timestamp),
             transaction.loanOffering.maxDuration,
             transaction.loanOffering.lender,
@@ -471,7 +469,6 @@ library ShortImpl {
             transaction.shortAmount,
             baseTokenReceived,
             transaction.depositAmount,
-            transaction.loanOffering.lockoutTime,
             transaction.loanOffering.callTimeLimit,
             transaction.loanOffering.maxDuration
         );
@@ -495,7 +492,7 @@ library ShortImpl {
     function parseShortTx(
         address[13] addresses,
         uint[17] values,
-        uint32[3] values32,
+        uint32[2] values32,
         uint8[2] sigV,
         bytes32[4] sigRS
     )
@@ -529,7 +526,7 @@ library ShortImpl {
     function parseLoanOffering(
         address[13] addresses,
         uint[17] values,
-        uint32[3] values32,
+        uint32[2] values32,
         uint8[2] sigV,
         bytes32[4] sigRS
     )
@@ -546,9 +543,8 @@ library ShortImpl {
             takerFeeToken: addresses[7],
             rates: parseLoanOfferRates(values),
             expirationTimestamp: values[7],
-            lockoutTime: values32[0],
-            callTimeLimit: values32[1],
-            maxDuration: values32[2],
+            callTimeLimit: values32[0],
+            maxDuration: values32[1],
             salt: values[8],
             loanHash: 0,
             signature: parseLoanOfferingSignature(sigV, sigRS)
@@ -689,10 +685,9 @@ library ShortImpl {
     )
         internal
         pure
-        returns (uint32[3] _values)
+        returns (uint32[2] _values)
     {
         return [
-            transaction.loanOffering.lockoutTime,
             transaction.loanOffering.callTimeLimit,
             transaction.loanOffering.maxDuration
         ];

--- a/contracts/short/impl/ShortSellCommon.sol
+++ b/contracts/short/impl/ShortSellCommon.sol
@@ -28,7 +28,6 @@ library ShortSellCommon {
         uint closedAmount;
         uint interestRate;
         uint32 callTimeLimit;
-        uint32 lockoutTime;
         uint32 startTimestamp;   // Immutable, cannot be 0
         uint32 callTimestamp;
         uint32 maxDuration;
@@ -45,7 +44,6 @@ library ShortSellCommon {
         address takerFeeToken;
         LoanRates rates;
         uint expirationTimestamp;
-        uint32 lockoutTime;
         uint32 callTimeLimit;
         uint32 maxDuration;
         uint salt;
@@ -229,7 +227,6 @@ library ShortSellCommon {
             loanOffering.rates.lenderFee,
             loanOffering.rates.takerFee,
             loanOffering.expirationTimestamp,
-            loanOffering.lockoutTime,
             loanOffering.callTimeLimit,
             loanOffering.maxDuration,
             loanOffering.salt
@@ -268,7 +265,6 @@ library ShortSellCommon {
             closedAmount,
             interestRate,
             callTimeLimit,
-            lockoutTime,
             startTimestamp,
             callTimestamp,
             maxDuration,
@@ -286,7 +282,6 @@ library ShortSellCommon {
             closedAmount: closedAmount,
             interestRate: interestRate,
             callTimeLimit: callTimeLimit,
-            lockoutTime: lockoutTime,
             startTimestamp: startTimestamp,
             callTimestamp: callTimestamp,
             maxDuration: maxDuration,

--- a/contracts/short/impl/ShortSellEvents.sol
+++ b/contracts/short/impl/ShortSellEvents.sol
@@ -28,7 +28,6 @@ contract ShortSellEvents {
         uint shortAmount,
         uint baseTokenFromSell,
         uint depositAmount,
-        uint32 lockoutTime,
         uint32 callTimeLimit,
         uint32 maxDuration,
         uint interestRate

--- a/contracts/short/interfaces/LoanOfferingVerifier.sol
+++ b/contracts/short/interfaces/LoanOfferingVerifier.sol
@@ -44,9 +44,8 @@ contract LoanOfferingVerifier {
      *
      * @param  values32         Values corresponding to:
      *
-     *  [0] = loan lockout time     (in seconds)
-     *  [1] = loan call time limit  (in seconds)
-     *  [2] = loan maxDuration      (in seconds)
+     *  [0] = loan call time limit  (in seconds)
+     *  [1] = loan maxDuration      (in seconds)
      *
      * @return _isValid     true if the contract consents to this loan, false if not.
      *                      If false, the loan will not occur
@@ -54,7 +53,7 @@ contract LoanOfferingVerifier {
     function verifyLoanOffering(
         address[8] addresses,
         uint[9] values256,
-        uint32[3] values32,
+        uint32[2] values32,
         bytes32 shortId
     )
         external

--- a/contracts/testing/SmartContractLender.sol
+++ b/contracts/testing/SmartContractLender.sol
@@ -17,7 +17,7 @@ contract SmartContractLender {
     function verifyLoanOffering(
         address[8],
         uint[9],
-        uint32[3],
+        uint32[2],
         bytes32
     )
         external

--- a/test/ShortSell/TestLoanCalling.js
+++ b/test/ShortSell/TestLoanCalling.js
@@ -26,8 +26,6 @@ describe('#callInLoan', () => {
       const shortSell = await ShortSell.deployed();
       const shortTx = await doShort(accounts);
 
-      await wait(shortTx.loanOffering.lockoutTime);
-
       const tx = await shortSell.callInLoan(
         shortTx.id,
         { from: shortTx.loanOffering.lender }
@@ -44,27 +42,9 @@ describe('#callInLoan', () => {
   });
 
   contract('ShortSell', function(accounts) {
-    it('enforces the lender waits the lockoutTime before calling', async () => {
-      const shortSell = await ShortSell.deployed();
-      const shortTx = await doShort(accounts);
-
-      await expectThrow(() => shortSell.callInLoan(
-        shortTx.id,
-        { from: shortTx.loanOffering.lender }
-      ));
-
-      const { callTimestamp } = await getShort(shortSell, shortTx.id);
-
-      expect(callTimestamp).to.be.bignumber.equal(0);
-    });
-  });
-
-  contract('ShortSell', function(accounts) {
     it('only allows the lender to call', async () => {
       const shortSell = await ShortSell.deployed();
       const shortTx = await doShort(accounts);
-
-      await wait(shortTx.loanOffering.lockoutTime);
 
       await expectThrow(() => shortSell.callInLoan(
         shortTx.id,
@@ -81,8 +61,6 @@ describe('#callInLoan', () => {
     it('fails if the loan has already been called', async () => {
       const shortSell = await ShortSell.deployed();
       const shortTx = await doShort(accounts);
-
-      await wait(shortTx.loanOffering.lockoutTime);
 
       const tx = await shortSell.callInLoan(
         shortTx.id,
@@ -109,8 +87,6 @@ describe('#cancelLoanCall', () => {
       const shortSell = await ShortSell.deployed();
       const shortTx = await doShort(accounts);
 
-      await wait(shortTx.loanOffering.lockoutTime);
-
       await shortSell.callInLoan(
         shortTx.id,
         { from: shortTx.loanOffering.lender }
@@ -134,8 +110,6 @@ describe('#cancelLoanCall', () => {
       const shortSell = await ShortSell.deployed();
       const shortTx = await doShort(accounts);
 
-      await wait(shortTx.loanOffering.lockoutTime);
-
       const tx = await shortSell.callInLoan(
         shortTx.id,
         { from: shortTx.loanOffering.lender }
@@ -157,8 +131,6 @@ describe('#cancelLoanCall', () => {
     it('fails if the loan has not been called', async () => {
       const shortSell = await ShortSell.deployed();
       const shortTx = await doShort(accounts);
-
-      await wait(shortTx.loanOffering.lockoutTime);
 
       await expectThrow(() => shortSell.cancelLoanCall(
         shortTx.id,

--- a/test/ShortSell/TestShort.js
+++ b/test/ShortSell/TestShort.js
@@ -170,7 +170,6 @@ async function checkSuccess(shortSell, shortTx) {
   expect(short.shortAmount).to.be.bignumber.equal(shortTx.shortAmount);
   expect(short.interestRate).to.be.bignumber.equal(proratedInterestRate);
   expect(short.callTimeLimit).to.be.bignumber.equal(shortTx.loanOffering.callTimeLimit);
-  expect(short.lockoutTime).to.be.bignumber.equal(shortTx.loanOffering.lockoutTime);
   expect(short.lender).to.equal(shortTx.loanOffering.lender);
   expect(short.seller).to.equal(shortTx.seller);
   expect(short.closedAmount).to.be.bignumber.equal(0);

--- a/test/ShortSell/TestShortSellAdmin.js
+++ b/test/ShortSell/TestShortSellAdmin.js
@@ -111,8 +111,6 @@ describe('#onlyWhileOperational', () => {
       const shortSell = await ShortSell.deployed();
       const shortTx = await doShort(accounts);
 
-      await wait(shortTx.loanOffering.lockoutTime);
-
       await shortSell.callInLoan(
         shortTx.id,
         { from: shortTx.loanOffering.lender }

--- a/test/ShortSell/TestShortSellRepo.js
+++ b/test/ShortSell/TestShortSellRepo.js
@@ -20,7 +20,6 @@ const shortAmount =    new BigNumber('1000');
 const interestRate =   new BigNumber('1');
 const callTimestamp =  new BigNumber('444');
 const callTimeLimit =  new BigNumber('222');
-const lockoutTime =    new BigNumber('333');
 const startTimestamp = new BigNumber('4444');
 const maxDuration =    new BigNumber('6666');
 const lender1 =        ADDRESSES.TEST[0];
@@ -36,7 +35,6 @@ async function createAddShort(shortRepo, shortId, account) {
     shortAmount,
     interestRate,
     callTimeLimit,
-    lockoutTime,
     startTimestamp,
     maxDuration,
     lender1,
@@ -52,7 +50,6 @@ async function getShort(shortRepo, shortId) {
     closedAmount,
     interestRate,
     callTimeLimit,
-    lockoutTime,
     startTimestamp,
     callTimestamp,
     maxDuration,
@@ -66,7 +63,6 @@ async function getShort(shortRepo, shortId) {
     closedAmount,
     interestRate,
     callTimeLimit,
-    lockoutTime,
     startTimestamp,
     callTimestamp,
     maxDuration,
@@ -120,7 +116,6 @@ contract('ShortSellRepo', function(accounts) {
       expect(s.startTimestamp).to.be.bignumber.not.equal(0);
       expect(s.callTimestamp).to.be.bignumber.equal(0);
       expect(s.callTimeLimit).to.be.bignumber.equal(callTimeLimit);
-      expect(s.lockoutTime).to.be.bignumber.equal(lockoutTime);
       expect(s.maxDuration).to.be.bignumber.equal(maxDuration);
     });
 
@@ -137,7 +132,6 @@ contract('ShortSellRepo', function(accounts) {
         shortAmount,
         interestRate,
         callTimeLimit,
-        lockoutTime,
         0, /* startTimestamp */
         maxDuration,
         lender1,

--- a/test/helpers/ShortSellHelper.js
+++ b/test/helpers/ShortSellHelper.js
@@ -108,7 +108,6 @@ function callShort(shortSell, tx) {
   ];
 
   const values32 = [
-    tx.loanOffering.lockoutTime,
     tx.loanOffering.callTimeLimit,
     tx.loanOffering.maxDuration
   ];
@@ -289,7 +288,6 @@ function callCancelLoanOffer(shortSell, loanOffering, cancelAmount, from) {
   ];
 
   const values32 = [
-    loanOffering.lockoutTime,
     loanOffering.callTimeLimit,
     loanOffering.maxDuration
   ];
@@ -391,7 +389,6 @@ async function createLoanOffering(accounts) {
       takerFee: BASE_AMOUNT.times(new BigNumber(.02))
     },
     expirationTimestamp: 1000000000000,
-    lockoutTime: 10000,
     callTimeLimit: 10000,
     maxDuration: 365 * BIGNUMBERS.ONE_DAY_IN_SECONDS,
     salt: 123
@@ -412,7 +409,6 @@ async function signLoanOffering(loanOffering) {
     loanOffering.rates.lenderFee,
     loanOffering.rates.takerFee,
     loanOffering.expirationTimestamp,
-    { type: 'uint32', value: loanOffering.lockoutTime },
     { type: 'uint32', value: loanOffering.callTimeLimit },
     { type: 'uint32', value: loanOffering.maxDuration },
     loanOffering.salt
@@ -521,7 +517,6 @@ async function getShort(shortSell, id) {
     closedAmount,
     interestRate,
     callTimeLimit,
-    lockoutTime,
     startTimestamp,
     callTimestamp,
     maxDuration,
@@ -536,7 +531,6 @@ async function getShort(shortSell, id) {
     closedAmount,
     interestRate,
     callTimeLimit,
-    lockoutTime,
     startTimestamp,
     callTimestamp,
     maxDuration,
@@ -568,7 +562,6 @@ async function doShortAndCall(accounts) {
 
   const shortTx = await doShort(accounts);
 
-  await wait(shortTx.loanOffering.lockoutTime);
   await shortSell.callInLoan(
     shortTx.id,
     { from: shortTx.loanOffering.lender }


### PR DESCRIPTION
We decided to remove `lockoutTime` from the base protocol as it can be implemented in second layer contracts