### PR TITLE
Make short quote token per unit consistent

### DIFF
--- a/contracts/short/impl/AddValueToShortImpl.sol
+++ b/contracts/short/impl/AddValueToShortImpl.sol
@@ -134,11 +134,21 @@ library AddValueToShortImpl {
     {
         uint256 quoteTokenBalance = Vault(state.VAULT).balances(shortId, transaction.quoteToken);
 
-        return MathHelpers.getPartialAmountRoundedUp(
+        uint256 minimumQuoteTokenRoundedDown = MathHelpers.getPartialAmountRoundedUp(
             transaction.effectiveAmount,
             short.shortAmount,
             quoteTokenBalance
         );
+
+        if (
+            quoteTokenBalance.div(short.shortAmount)
+            == quoteTokenBalance.add(minimumQuoteTokenRoundedDown)
+                .div(short.shortAmount.add(short.shortAmount))
+        ) {
+            return minimumQuoteTokenRoundedDown;
+        }
+
+        return minimumQuoteTokenRoundedDown.add(1);
     }
 
     function validateAndSetDepositAmount(


### PR DESCRIPTION
Right now, we just always round `positionMinimumQuoteToken` up, so it could go up slowly over time. Instead we should calculate `positionMinimumQuoteToken` such that it makes quote token per unit always the same after an addition