### PR TITLE
Fix expired loan tests

### DIFF
--- a/test/ShortSell/TestCancelLoan.js
+++ b/test/ShortSell/TestCancelLoan.js
@@ -1,98 +1,103 @@
-/*global artifacts, contract, describe, it*/
+/*global artifacts, contract, describe, before, it*/
 
 const chai = require('chai');
 chai.use(require('chai-bignumber')());
 const BigNumber = require('bignumber.js');
 
 const ShortSell = artifacts.require("ShortSell");
-const {
-  createShortSellTx,
-  callCancelLoanOffer
-} = require('../helpers/ShortSellHelper');
 const { expectThrow } = require('../helpers/ExpectHelper');
+const { createLoanOffering, signLoanOffering} = require('../helpers/LoanHelper');
+const { getBlockTimestamp } = require('../helpers/NodeHelper');
+const { callCancelLoanOffer } = require('../helpers/ShortSellHelper');
 
 describe('#cancelLoanOffering', () => {
+  let shortSell;
+  let additionalSalt = 888;
+
+  async function getNewLoanOffering(accounts) {
+    let loanOffering = await createLoanOffering(accounts);
+    loanOffering.salt += (additionalSalt++);
+    loanOffering.signature = await signLoanOffering(loanOffering);
+    return loanOffering;
+  }
+
   contract('ShortSell', function(accounts) {
+    before('get shortSell', async () => {
+      shortSell = await ShortSell.deployed();
+    });
+
     it('cancels an amount of a loan offering', async () => {
-      const shortSell = await ShortSell.deployed();
-      const shortTx = await createShortSellTx(accounts);
+      const loanOffering = await getNewLoanOffering(accounts);
       const cancelAmount = new BigNumber(1000);
 
-      const tx = await callCancelLoanOffer(shortSell, shortTx.loanOffering, cancelAmount);
+      const tx = await callCancelLoanOffer(shortSell, loanOffering, cancelAmount);
 
       console.log('\tShortSell.cancelLoanOffering gas used: ' + tx.receipt.gasUsed);
     });
-  });
 
-  contract('ShortSell', function(accounts) {
     it('increments canceled amount if already partially canceled', async () => {
-      const shortSell = await ShortSell.deployed();
-      const shortTx = await createShortSellTx(accounts);
+      const loanOffering = await getNewLoanOffering(accounts);
       const cancelAmount = new BigNumber(1000);
       const cancelAmount2 = new BigNumber(2000);
 
-      await callCancelLoanOffer(shortSell, shortTx.loanOffering, cancelAmount);
+      await callCancelLoanOffer(shortSell, loanOffering, cancelAmount);
 
-      await callCancelLoanOffer(shortSell, shortTx.loanOffering, cancelAmount2);
+      await callCancelLoanOffer(shortSell, loanOffering, cancelAmount2);
     });
-  });
 
-  contract('ShortSell', function(accounts) {
     it('only cancels up to the maximum amount', async () => {
-      const shortSell = await ShortSell.deployed();
-      const shortTx = await createShortSellTx(accounts);
-      const cancelAmount = shortTx.loanOffering.rates.maxAmount.times(2).div(3).floor();
+      const loanOffering = await getNewLoanOffering(accounts);
+      const cancelAmount = loanOffering.rates.maxAmount.times(2).div(3).floor();
 
-      await callCancelLoanOffer(shortSell, shortTx.loanOffering, cancelAmount);
+      await callCancelLoanOffer(shortSell, loanOffering, cancelAmount);
 
-      await callCancelLoanOffer(shortSell, shortTx.loanOffering, cancelAmount);
+      await callCancelLoanOffer(shortSell, loanOffering, cancelAmount);
     });
-  });
 
-  contract('ShortSell', function(accounts) {
     it('only allows the lender to cancel', async () => {
-      const shortSell = await ShortSell.deployed();
-      const shortTx = await createShortSellTx(accounts);
+      const loanOffering = await getNewLoanOffering(accounts);
 
       await expectThrow(() =>
         callCancelLoanOffer(
           shortSell,
-          shortTx.loanOffering,
-          shortTx.loanOffering.rates.maxAmount,
+          loanOffering,
+          loanOffering.rates.maxAmount,
           accounts[9])
       );
     });
-  });
 
-  //TODO: when we can roll-back evm time after this super long wait
-  /*
-  contract('ShortSell', function(_accounts) {
     it('does not cancel if past expirationTimestamp anyway', async () => {
-      const shortSell = await ShortSell.deployed();
-      const shortTx = await createShortSellTx(accounts);
-      const cancelAmount = shortTx.loanOffering.rates.maxAmount.div(4);
+      const loanOffering = await getNewLoanOffering(accounts);
+      const cancelAmount = loanOffering.rates.maxAmount.div(4);
 
-      await callCancelLoanOffer(
+      const tx = await callCancelLoanOffer(
         shortSell,
-        shortTx.loanOffering,
-        cancelAmount
-      );
-      await callCancelLoanOffer(
-        shortSell,
-        shortTx.loanOffering,
+        loanOffering,
         cancelAmount
       );
 
-      await wait(shortTx.loanOffering.expirationTimestamp);
+      const now = await getBlockTimestamp(tx.receipt.blockNumber);
 
-      await expectThrow(() =>
-        callCancelLoanOffer(
-          shortSell,
-          shortTx.loanOffering,
-          cancelAmount
-        )
+      // Test unexpired loan offering
+      let loanOfferingGood = Object.assign({}, loanOffering);
+      loanOfferingGood.expirationTimestamp = new BigNumber(now).plus(1000);
+      loanOfferingGood.signature = await signLoanOffering(loanOfferingGood);
+      await callCancelLoanOffer(
+        shortSell,
+        loanOfferingGood,
+        cancelAmount
       );
+
+      // Test expired loan offering
+      let loanOfferingBad = Object.assign({}, loanOffering);
+      loanOfferingBad.expirationTimestamp = new BigNumber(now);
+      loanOfferingBad.signature = await signLoanOffering(loanOfferingBad);
+      await expectThrow(() => callCancelLoanOffer(
+        shortSell,
+        loanOfferingBad,
+        cancelAmount
+      ));
+
     });
   });
-  */
 });


### PR DESCRIPTION
Let me know what you think of this solution

Most of the pull request is changing to using `createLoanOffering()` directly since a whole `shortTx` is not needed.

But then I also add a test. Instead of waiting for the loan to expire, we just create a pair of loans (one expiring X seconds into the future and one expiring now) and then assert the expected behavior (i.e. one reverts and one does not)

No-merge because I want to change this one other place if this looks good