### PR TITLE
Fix Buying Back Owed Token

### DIFF
--- a/contracts/margin/impl/ClosePositionImpl.sol
+++ b/contracts/margin/impl/ClosePositionImpl.sol
@@ -171,7 +171,7 @@ library ClosePositionImpl {
         );
 
         if (transaction.payoutInHeldToken) {
-            assert(receivedOwedToken == transaction.owedTokenOwed);
+            assert(receivedOwedToken >= transaction.owedTokenOwed);
         } else {
             require(receivedOwedToken >= transaction.owedTokenOwed);
         }
@@ -181,7 +181,7 @@ library ClosePositionImpl {
             transaction.owedToken,
             transaction.exchangeWrapper,
             transaction.positionLender,
-            transaction.owedTokenOwed
+            receivedOwedToken
         );
 
         return (heldTokenPrice, receivedOwedToken);

--- a/test/helpers/0xHelper.js
+++ b/test/helpers/0xHelper.js
@@ -22,7 +22,7 @@ async function createSignedSellOrder(accounts, _salt = DEFAULT_SALT) {
     maker: accounts[5],
     makerFee: BIGNUMBERS.BASE_AMOUNT.times(new BigNumber(.01)),
     makerTokenAddress: OwedToken.address,
-    makerTokenAmount: BIGNUMBERS.BASE_AMOUNT.times(new BigNumber(2)),
+    makerTokenAmount: BIGNUMBERS.BASE_AMOUNT.times(new BigNumber(2.382472)),
     salt: new BigNumber(_salt),
     taker: ZeroEx.NULL_ADDRESS,
     takerFee: BIGNUMBERS.BASE_AMOUNT.times(new BigNumber(.1)),

--- a/test/helpers/ClosePositionHelper.js
+++ b/test/helpers/ClosePositionHelper.js
@@ -36,7 +36,14 @@ async function checkSuccess(dydxMargin, OpenTx, closeTx, sellOrder, closeAmount)
   const heldTokenBuybackCost = getPartialAmount(
     sellOrder.takerTokenAmount,
     sellOrder.makerTokenAmount,
-    owedTokenOwedToLender
+    owedTokenOwedToLender,
+    true // round up
+  );
+
+  const owedTokenPaidToLender = getPartialAmount(
+    heldTokenBuybackCost,
+    sellOrder.takerTokenAmount,
+    sellOrder.makerTokenAmount,
   );
 
   const balances = await getBalances(dydxMargin, OpenTx, sellOrder);
@@ -50,7 +57,7 @@ async function checkSuccess(dydxMargin, OpenTx, closeTx, sellOrder, closeAmount)
   } = balances;
 
   checkSmartContractBalances(balances, OpenTx, closeAmount);
-  checkLenderBalances(balances, owedTokenOwedToLender, OpenTx);
+  checkLenderBalances(balances, owedTokenPaidToLender, OpenTx);
 
   expect(traderHeldToken).to.be.bignumber.equal(
     getPartialAmount(
@@ -62,16 +69,16 @@ async function checkSuccess(dydxMargin, OpenTx, closeTx, sellOrder, closeAmount)
   );
   expect(externalEntityHeldToken).to.be.bignumber.equal(heldTokenBuybackCost);
   expect(externalEntityOwedToken).to.be.bignumber.equal(
-    sellOrder.makerTokenAmount.minus(owedTokenOwedToLender)
+    sellOrder.makerTokenAmount.minus(owedTokenPaidToLender)
   );
   expect(feeRecipientFeeToken).to.be.bignumber.equal(
     getPartialAmount(
-      owedTokenOwedToLender,
+      owedTokenPaidToLender,
       sellOrder.makerTokenAmount,
       sellOrder.takerFee
     ).plus(
       getPartialAmount(
-        owedTokenOwedToLender,
+        owedTokenPaidToLender,
         sellOrder.makerTokenAmount,
         sellOrder.makerFee
       )
@@ -97,7 +104,7 @@ async function checkSuccess(dydxMargin, OpenTx, closeTx, sellOrder, closeAmount)
       )
       .minus(
         getPartialAmount(
-          owedTokenOwedToLender,
+          owedTokenPaidToLender,
           sellOrder.makerTokenAmount,
           sellOrder.takerFee
         )
@@ -107,7 +114,7 @@ async function checkSuccess(dydxMargin, OpenTx, closeTx, sellOrder, closeAmount)
     sellOrder.makerFee
       .minus(
         getPartialAmount(
-          owedTokenOwedToLender,
+          owedTokenPaidToLender,
           sellOrder.makerTokenAmount,
           sellOrder.makerFee
         )

--- a/test/margin/TestMarginAdmin.js
+++ b/test/margin/TestMarginAdmin.js
@@ -180,7 +180,7 @@ describe('MarginAdmin', () => {
   });
 
   describe('#cancelLoanStateControl', () => {
-    const cancelAmount = new BigNumber(100);
+    const cancelAmount = new BigNumber(100000);
 
     async function test(accounts, state, shouldFail = false) {
       const OpenTx = await doOpenPosition(accounts);
@@ -231,7 +231,7 @@ describe('MarginAdmin', () => {
   });
 
   describe('#closePositionStateControl', () => {
-    const closeAmount = new BigNumber(100);
+    const closeAmount = new BigNumber(100000);
 
     async function test(accounts, state, shouldFail = false) {
       const OpenTx = await doOpenPosition(accounts);
@@ -276,7 +276,7 @@ describe('MarginAdmin', () => {
 
 
   describe('#closePositionDirectlyStateControl', () => {
-    const closeAmount = new BigNumber(100);
+    const closeAmount = new BigNumber(100000);
     async function test(accounts, state) {
       const OpenTx = await doOpenPosition(accounts);
       const dydxMargin = await Margin.deployed();


### PR DESCRIPTION
You cannot always buy back an exact amount of `owedToken` with a given order. If extra owed token is bought back with the order, just send that to the lender as well. Previously, the transaction would have thrown