### PR TITLE
add zero-amount token check to TokenInteract.transfer{from}

### DIFF
--- a/contracts/lib/TokenInteract.sol
+++ b/contracts/lib/TokenInteract.sol
@@ -51,7 +51,9 @@ library TokenInteract {
     )
         internal
     {
-        require(ERC20(token).transfer(to, amount));
+        if (amount > 0) {
+            require(ERC20(token).transfer(to, amount));
+        }
     }
 
     function transferFrom(
@@ -62,6 +64,8 @@ library TokenInteract {
     )
         internal
     {
-        require(ERC20(token).transferFrom(from, to, amount));
+        if (amount > 0) {
+            require(ERC20(token).transferFrom(from, to, amount));
+        }
     }
 }

--- a/contracts/margin/external/ZeroExExchangeWrapper.sol
+++ b/contracts/margin/external/ZeroExExchangeWrapper.sol
@@ -251,14 +251,12 @@ contract ZeroExExchangeWrapper is
             order.takerFee
         );
 
-        if (takerFee > 0) {
-            TokenInteract.transferFrom(
-                ZRX,
-                tradeOriginator,
-                address(this),
-                takerFee
-            );
-        }
+        TokenInteract.transferFrom(
+            ZRX,
+            tradeOriginator,
+            address(this),
+            takerFee
+        );
     }
 
     function doTrade(

--- a/contracts/margin/impl/ClosePositionImpl.sol
+++ b/contracts/margin/impl/ClosePositionImpl.sol
@@ -171,14 +171,12 @@ library ClosePositionImpl {
         }
 
         // Send the requisite heldToken to do the buyback from vault to exchange wrapper
-        if (heldTokenPrice > 0) {
-            Vault(state.VAULT).transferFromVault(
-                transaction.positionId,
-                transaction.heldToken,
-                transaction.exchangeWrapper,
-                heldTokenPrice
-            );
-        }
+        Vault(state.VAULT).transferFromVault(
+            transaction.positionId,
+            transaction.heldToken,
+            transaction.exchangeWrapper,
+            heldTokenPrice
+        );
 
         // Trade the heldToken for the owedToken
         uint256 receivedOwedToken = ExchangeWrapper(transaction.exchangeWrapper).exchange(

--- a/contracts/margin/impl/ClosePositionShared.sol
+++ b/contracts/margin/impl/ClosePositionShared.sol
@@ -76,27 +76,23 @@ library ClosePositionShared {
             // Send remaining heldToken to payoutRecipient
             payout = transaction.availableHeldToken.sub(buybackCost);
 
-            if (payout > 0) {
-                Vault(state.VAULT).transferFromVault(
-                    transaction.positionId,
-                    transaction.heldToken,
-                    transaction.payoutRecipient,
-                    payout
-                );
-            }
+            Vault(state.VAULT).transferFromVault(
+                transaction.positionId,
+                transaction.heldToken,
+                transaction.payoutRecipient,
+                payout
+            );
         } else {
             assert(transaction.exchangeWrapper != address(0));
 
             payout = receivedOwedToken.sub(transaction.owedTokenOwed);
 
-            if (payout > 0) {
-                Proxy(state.PROXY).transferTokens(
-                    transaction.owedToken,
-                    transaction.exchangeWrapper,
-                    transaction.payoutRecipient,
-                    payout
-                );
-            }
+            Proxy(state.PROXY).transferTokens(
+                transaction.owedToken,
+                transaction.exchangeWrapper,
+                transaction.payoutRecipient,
+                payout
+            );
         }
 
         if (AddressUtils.isContract(transaction.payoutRecipient)) {

--- a/contracts/margin/impl/OpenPositionShared.sol
+++ b/contracts/margin/impl/OpenPositionShared.sol
@@ -200,24 +200,22 @@ library OpenPositionShared {
         internal
         returns (uint256 /* heldTokenFromDeposit */)
     {
-        if (transaction.depositAmount > 0) {
-            if (transaction.depositInHeldToken) {
-                Vault(state.VAULT).transferToVault(
-                    positionId,
-                    transaction.heldToken,
-                    msg.sender,
-                    transaction.depositAmount
-                );
-                return transaction.depositAmount;
-            } else {
-                Proxy(state.PROXY).transferTokens(
-                    transaction.owedToken,
-                    msg.sender,
-                    transaction.exchangeWrapper,
-                    transaction.depositAmount
-                );
-                return 0;
-            }
+        if (transaction.depositInHeldToken) {
+            Vault(state.VAULT).transferToVault(
+                positionId,
+                transaction.heldToken,
+                msg.sender,
+                transaction.depositAmount
+            );
+            return transaction.depositAmount;
+        } else {
+            Proxy(state.PROXY).transferTokens(
+                transaction.owedToken,
+                msg.sender,
+                transaction.exchangeWrapper,
+                transaction.depositAmount
+            );
+            return 0;
         }
     }
 


### PR DESCRIPTION
Remove check for calls directly to TokenInteract.transfer{from} which will now make the check

Remove check for calls unlikely to be 0

Keep checks for external calls likely to be 0