### PR TITLE
Always Increase Loan Offering Filled Amount Correctly

### DIFF
--- a/contracts/margin/impl/IncreasePositionImpl.sol
+++ b/contracts/margin/impl/IncreasePositionImpl.sol
@@ -86,10 +86,6 @@ library IncreasePositionImpl {
             transaction.loanOffering.payer
         );
 
-        // Update global amounts for the loan
-        state.loanFills[transaction.loanOffering.loanHash] =
-            state.loanFills[transaction.loanOffering.loanHash].add(transaction.principal);
-
         // LOG EVENT
         recordPositionIncreased(
             transaction,

--- a/contracts/margin/impl/OpenPositionImpl.sol
+++ b/contracts/margin/impl/OpenPositionImpl.sol
@@ -149,9 +149,7 @@ library OpenPositionImpl {
     {
         assert(!MarginCommon.containsPositionImpl(state, positionId));
 
-        // Update global amounts for the loan and lender
-        state.loanFills[transaction.loanOffering.loanHash] =
-            state.loanFills[transaction.loanOffering.loanHash].add(transaction.principal);
+        // Update global amounts for the loan
         state.loanNumbers[transaction.loanOffering.loanHash] =
             state.loanNumbers[transaction.loanOffering.loanHash].add(1);
 

--- a/contracts/margin/impl/OpenPositionShared.sol
+++ b/contracts/margin/impl/OpenPositionShared.sol
@@ -78,6 +78,10 @@ library OpenPositionShared {
         // Transfer feeTokens from trader and lender
         transferLoanFees(state, transaction);
 
+        // Update global amounts for the loan
+        state.loanFills[transaction.loanOffering.loanHash] =
+            state.loanFills[transaction.loanOffering.loanHash].add(transaction.lenderAmount);
+
         return (
             heldTokenFromSell,
             totalHeldTokenReceived

--- a/test/margin/TestOpenPosition.js
+++ b/test/margin/TestOpenPosition.js
@@ -298,7 +298,7 @@ async function checkSuccess(dydxMargin, OpenTx) {
   const [
     owedToken,
     heldToken,
-    feeToken
+    feeToken,
   ] = await Promise.all([
     OwedToken.deployed(),
     HeldToken.deployed(),
@@ -315,7 +315,8 @@ async function checkSuccess(dydxMargin, OpenTx) {
     lenderFeeToken,
     makerFeeToken,
     exchangeWrapperFeeToken,
-    traderFeeToken
+    traderFeeToken,
+    loanOfferingFilledAmount
   ] = await Promise.all([
     owedToken.balanceOf.call(OpenTx.loanOffering.payer),
     owedToken.balanceOf.call(OpenTx.buyOrder.maker),
@@ -327,6 +328,7 @@ async function checkSuccess(dydxMargin, OpenTx) {
     feeToken.balanceOf.call(OpenTx.buyOrder.maker),
     feeToken.balanceOf.call(ExchangeWrapper.address),
     feeToken.balanceOf.call(OpenTx.trader),
+    dydxMargin.loanFills.call(OpenTx.loanOffering.loanHash)
   ]);
 
   expect(lenderOwedToken).to.be.bignumber.equal(
@@ -378,4 +380,5 @@ async function checkSuccess(dydxMargin, OpenTx) {
         )
       )
   );
+  expect(loanOfferingFilledAmount).to.be.bignumber.eq(OpenTx.principal);
 }


### PR DESCRIPTION
We should always increase the filled amount on the loan offering by the amount that was actually lent, rather than the principal that was added to the position.

Also move the update into `OpenPositionShared` as it is shared between open and increase

Add tests