### PR TITLE
Fix ERC20Position Closing For Longs

### DIFF
--- a/contracts/margin/external/ERC20/ERC20Long.sol
+++ b/contracts/margin/external/ERC20/ERC20Long.sol
@@ -14,6 +14,9 @@ import { MathHelpers } from "../../../lib/MathHelpers.sol";
  * Contract used to tokenize leveraged long positions and allow them to be used as ERC20-compliant
  * tokens. Holding the tokens allows the holder to close a piece of the position, or be
  * entitled to some amount of heldTokens after settlement.
+ *
+ * The total supply of leveraged long tokens is always exactly equal to the number of heldTokens
+ * held in collateral in the backing position
  */
 contract ERC20Long is ERC20Position {
     constructor(
@@ -58,6 +61,14 @@ contract ERC20Long is ERC20Position {
         return positionBalance.sub(totalSupply_);
     }
 
+    /**
+     * The amount of long tokens burned on a close is always exactly equal to the amount of
+     * heldTokens used for the close in the backing position
+     *
+     * NOTE: It's possible that it is impossible for a token holder to close his entire token
+     *       balance. If the principal of the backing position is less than the supply of long
+     *       tokens it is not possible to express every token amount in a principal amount.
+     */
     function getCloseAmounts(
         uint256 requestedCloseAmount,
         uint256 balance,
@@ -66,8 +77,8 @@ contract ERC20Long is ERC20Position {
         internal
         view
         returns (
-            uint256,
-            uint256
+            uint256 /* tokenAmount */,
+            uint256 /* allowedCloseAmount */
         )
     {
         uint256 requestedTokenAmount = MathHelpers.getPartialAmount(
@@ -80,19 +91,21 @@ contract ERC20Long is ERC20Position {
             return (requestedTokenAmount, requestedCloseAmount);
         }
 
-        uint256 maxAllowedAmount = MathHelpers.getPartialAmount(
+        // The maximum amount of principal able to be closed without using more heldTokens
+        // than balance
+        uint256 maxAllowedCloseAmount = MathHelpers.getPartialAmount(
             balance,
             totalSupply_,
             positionPrincipal
         );
 
         uint256 tokenAmount = MathHelpers.getPartialAmount(
-            maxAllowedAmount,
+            maxAllowedCloseAmount,
             positionPrincipal,
             totalSupply_
         );
 
-        return (tokenAmount, maxAllowedAmount);
+        return (tokenAmount, maxAllowedCloseAmount);
     }
 
     function getNameIntro()

--- a/contracts/margin/external/ERC20/ERC20Position.sol
+++ b/contracts/margin/external/ERC20/ERC20Position.sol
@@ -436,18 +436,18 @@ contract ERC20Position is
     {
         uint256 balance = balances[closer];
         uint256 tokenAmount;
-        uint256 allowedAmount;
+        uint256 allowedCloseAmount;
 
-        (tokenAmount, allowedAmount) = getCloseAmounts(
+        (tokenAmount, allowedCloseAmount) = getCloseAmounts(
             requestedAmount,
             balance,
             positionPrincipal
         );
 
-        require(tokenAmount > 0 && allowedAmount > 0);
+        require(tokenAmount > 0 && allowedCloseAmount > 0);
 
         assert(tokenAmount <= balance);
-        assert(allowedAmount <= requestedAmount);
+        assert(allowedCloseAmount <= requestedAmount);
 
         balances[closer] = balance.sub(tokenAmount);
         totalSupply_ = totalSupply_.sub(tokenAmount);
@@ -459,7 +459,7 @@ contract ERC20Position is
             emit CompletelyClosed();
         }
 
-        return allowedAmount;
+        return allowedCloseAmount;
     }
 
     // ============ Internal Abstract Functions ============
@@ -481,7 +481,7 @@ contract ERC20Position is
         view
         returns (
             uint256 /* tokenAmount */,
-            uint256 /* allowedAmount */
+            uint256 /* allowedCloseAmount */
         );
 
     function getNameIntro()

--- a/contracts/margin/external/ERC20/ERC20Short.sol
+++ b/contracts/margin/external/ERC20/ERC20Short.sol
@@ -14,6 +14,9 @@ import { Margin } from "../../Margin.sol";
  * Contract used to tokenize short positions and allow them to be used as ERC20-compliant
  * tokens. Holding the tokens allows the holder to close a piece of the short position, or be
  * entitled to some amount of heldTokens after settlement.
+ *
+ * The total supply of short tokens is always exactly equal to the amount of principal in
+ * the backing position
  */
 contract ERC20Short is ERC20Position {
     constructor(
@@ -66,8 +69,8 @@ contract ERC20Short is ERC20Position {
         internal
         view
         returns (
-            uint256,
-            uint256
+            uint256 /* tokenAmount */,
+            uint256 /* allowedCloseAmount */
         )
     {
         assert(positionPrincipal == totalSupply_);


### PR DESCRIPTION
We currently assume the `requestedAmount` on `closeOnBehalfOf` is equal to the token amount. This is true for short tokens, but not for long tokens. We need to calculate the token amount to close given the `requestedAmount` for long tokens.



NOTE: It is possible that it's impossible for a long token holder to close all of their tokens. e.g. if they request to close the maximum amount, it's possible some dust amount of tokens could be leftover.

This is because we denominate the close amount in terms of principal, and if principal < collateral it is not possible to express every amount of collateral by just passing in a principal amount. We considered other approaches to fix this, but ultimately decided this was the best approach.