### PR TITLE
Allow multiple 721 position tokens to be burned

### DIFF
--- a/contracts/margin/external/ERC721/ERC721MarginPosition.sol
+++ b/contracts/margin/external/ERC721/ERC721MarginPosition.sol
@@ -158,23 +158,23 @@ contract ERC721MarginPosition is
      *
      * @param  positionId  Unique ID of the position
      */
-    function burnTokenSafe(
+    function burnClosedToken(
         bytes32 positionId
     )
         external
         nonReentrant
     {
-        burnTokenSafeInternal(positionId);
+        burnClosedTokenInternal(positionId);
     }
 
-    function burnTokenSafeMultiple(
+    function burnClosedTokenMultiple(
         bytes32[] positionIds
     )
         external
         nonReentrant
     {
         for (uint256 i = 0; i < positionIds.length; i++) {
-            burnTokenSafeInternal(positionId);
+            burnClosedTokenInternal(positionIds[i]);
         }
     }
 
@@ -282,12 +282,12 @@ contract ERC721MarginPosition is
 
     // ============ Internal Functions ============
 
-    function burnTokenSafeInternal(
+    function burnClosedTokenInternal(
         bytes32 positionId
     )
         internal
     {
-        require(!Margin(DYDX_MARGIN).containsPosition(positionId));
+        require(Margin(DYDX_MARGIN).isPositionClosed(positionId));
         _burn(ownerOf(uint256(positionId)), uint256(positionId));
     }
 }


### PR DESCRIPTION
Add a helper function to enable multiple ERC721 position tokens to be burned in one transaction