### PR TITLE
add unit-tested comment flag for hiding asserts

### DIFF
--- a/contracts/lib/FractionMath.sol
+++ b/contracts/lib/FractionMath.sol
@@ -141,7 +141,7 @@ library FractionMath {
             den /= first128Bits;
         }
 
-        assert(den != 0 && den < 2**128 && num < 2**128);
+        assert(den != 0 && den < 2**128 && num < 2**128); // unit-tested
 
         return Fraction.Fraction128({
             num: uint128(num),
@@ -155,7 +155,7 @@ library FractionMath {
         internal
         pure
     {
-        assert(a.den != 0);
+        assert(a.den != 0); // unit-tested
     }
 
     function copy(

--- a/contracts/lib/MathHelpers.sol
+++ b/contracts/lib/MathHelpers.sol
@@ -86,7 +86,7 @@ library MathHelpers {
         pure
         returns (uint256)
     {
-        assert(denominator != 0);
+        assert(denominator != 0); // unit-tested
         if (numerator == 0) {
             return 0;
         }

--- a/util/hideasserts.py
+++ b/util/hideasserts.py
@@ -13,7 +13,7 @@ def hideAsserts(dir, filepath):
     # parse entire file
     for line in open(filepath, 'r').readlines():
         builder = line.rstrip();
-        if (line.lstrip().startswith('assert(')):
+        if (line.lstrip().startswith('assert(') and ('unit-tested' not in line)):
             inAnAssert = True
             numAssertsChanged += 1
             spacesToAdd = len(builder) - len(builder.lstrip()) - 2;
@@ -42,9 +42,6 @@ def main():
 
     for dir,_,_ in os.walk(dir_path+"/contracts"):
         files.extend(glob.glob(os.path.join(dir,pattern)))
-
-    whitelistedFiles = ['FractionMath.sol', 'MathHelpers.sol']
-    files = [x for x in files if not any(white in x for white in whitelistedFiles)]
 
     numHidden = 0
     for file in files:


### PR DESCRIPTION
if `unit-tested` is found on an assert line, then we won't hide that assert during coverage testing

This is similar to `solium-ignore` as it's more granular than whitelisting an entire file