### PR TITLE
Improve Interest Calculation Gas Costs

### DIFF
--- a/contracts/lib/Exponent.sol
+++ b/contracts/lib/Exponent.sol
@@ -75,7 +75,7 @@ library Exponent {
         }
 
         // get the integer value of the fraction (example: 9/4 is 2.25 so has integerValue of 2)
-        uint256 integerX = uint256(Xcopy.num).div(Xcopy.den);
+        uint256 integerX = Xcopy.num.div(Xcopy.den);
 
         // if X is less than 1, then just calculate X
         if (integerX == 0) {

--- a/contracts/lib/Exponent.sol
+++ b/contracts/lib/Exponent.sol
@@ -32,12 +32,12 @@ import { FractionMath } from "./FractionMath.sol";
  */
 library Exponent {
     using SafeMath for uint256;
-    using FractionMath for Fraction.Fraction128;
+    using FractionMath for Fraction.Fraction256;
 
     // ============ Constants ============
 
     // 2**128 - 1
-    uint128 constant public MAX_NUMERATOR = 340282366920938463463374607431768211455;
+    uint256 constant public MAX_NUMERATOR = 340282366920938463463374607431768211455;
 
     // Number of precomputed integers, X, for E^((1/2)^X)
     uint256 constant public MAX_PRECOMPUTE_PRECISION = 32;
@@ -56,20 +56,20 @@ library Exponent {
      * @return                      e^X
      */
     function exp(
-        Fraction.Fraction128 memory X,
+        Fraction.Fraction256 memory X,
         uint256 precomputePrecision,
         uint256 maclaurinPrecision
     )
         internal
         pure
-        returns (Fraction.Fraction128 memory)
+        returns (Fraction.Fraction256 memory)
     {
         require(
             precomputePrecision <= MAX_PRECOMPUTE_PRECISION,
             "Exponent#exp: Precompute precision over maximum"
         );
 
-        Fraction.Fraction128 memory Xcopy = X.copy();
+        Fraction.Fraction256 memory Xcopy = X.copy();
         if (Xcopy.num == 0) { // e^0 = 1
             return ONE();
         }
@@ -83,7 +83,7 @@ library Exponent {
         }
 
         // get e^integerX
-        Fraction.Fraction128 memory expOfInt =
+        Fraction.Fraction256 memory expOfInt =
             getPrecomputedEToThe(integerX % NUM_PRECOMPUTED_INTEGERS);
         while (integerX >= NUM_PRECOMPUTED_INTEGERS) {
             expOfInt = expOfInt.mul(getPrecomputedEToThe(NUM_PRECOMPUTED_INTEGERS));
@@ -91,7 +91,7 @@ library Exponent {
         }
 
         // multiply e^integerX by e^decimalX
-        Fraction.Fraction128 memory decimalX = Fraction.Fraction128({
+        Fraction.Fraction256 memory decimalX = Fraction.Fraction256({
             num: Xcopy.num % Xcopy.den,
             den: Xcopy.den
         });
@@ -108,24 +108,24 @@ library Exponent {
      * @return                      e^X
      */
     function expHybrid(
-        Fraction.Fraction128 memory X,
+        Fraction.Fraction256 memory X,
         uint256 precomputePrecision,
         uint256 maclaurinPrecision
     )
         internal
         pure
-        returns (Fraction.Fraction128 memory)
+        returns (Fraction.Fraction256 memory)
     {
         assert(precomputePrecision <= MAX_PRECOMPUTE_PRECISION);
         assert(X.num < X.den);
         // will also throw if precomputePrecision is larger than the array length in getDenominator
 
-        Fraction.Fraction128 memory Xtemp = X.copy();
+        Fraction.Fraction256 memory Xtemp = X.copy();
         if (Xtemp.num == 0) { // e^0 = 1
             return ONE();
         }
 
-        Fraction.Fraction128 memory result = ONE();
+        Fraction.Fraction256 memory result = ONE();
 
         uint256 d = 1; // 2^i
         for (uint256 i = 1; i <= precomputePrecision; i++) {
@@ -133,7 +133,7 @@ library Exponent {
 
             // if Fraction > 1/d, subtract 1/d and multiply result by precomputed e^(1/d)
             if (d.mul(Xtemp.num) >= Xtemp.den) {
-                Xtemp = Xtemp.sub1Over(uint128(d));
+                Xtemp = Xtemp.sub1Over(d);
                 result = result.mul(getPrecomputedEToTheHalfToThe(i));
             }
         }
@@ -151,22 +151,22 @@ library Exponent {
      * @return             e^X
      */
     function expMaclaurin(
-        Fraction.Fraction128 memory X,
+        Fraction.Fraction256 memory X,
         uint256 precision
     )
         internal
         pure
-        returns (Fraction.Fraction128 memory)
+        returns (Fraction.Fraction256 memory)
     {
-        Fraction.Fraction128 memory Xcopy = X.copy();
+        Fraction.Fraction256 memory Xcopy = X.copy();
         if (Xcopy.num == 0) { // e^0 = 1
             return ONE();
         }
 
-        Fraction.Fraction128 memory result = ONE();
-        Fraction.Fraction128 memory Xtemp = ONE();
+        Fraction.Fraction256 memory result = ONE();
+        Fraction.Fraction256 memory Xtemp = ONE();
         for (uint256 i = 1; i <= precision; i++) {
-            Xtemp = Xtemp.mul(Xcopy.div(uint128(i)));
+            Xtemp = Xtemp.mul(Xcopy.div(i));
             result = result.add(Xtemp);
         }
         return result;
@@ -180,11 +180,11 @@ library Exponent {
     )
         internal
         pure
-        returns (Fraction.Fraction128 memory)
+        returns (Fraction.Fraction256 memory)
     {
         assert(x <= MAX_PRECOMPUTE_PRECISION);
 
-        uint128 denominator = [
+        uint256 denominator = [
             125182886983370532117250726298150828301,
             206391688497133195273760705512282642279,
             265012173823417992016237332255925138361,
@@ -219,7 +219,7 @@ library Exponent {
             340282366762482138471739420386372790954,
             340282366841710300958333641874363209044
         ][x];
-        return Fraction.Fraction128({
+        return Fraction.Fraction256({
             num: MAX_NUMERATOR,
             den: denominator
         });
@@ -233,11 +233,11 @@ library Exponent {
     )
         internal
         pure
-        returns (Fraction.Fraction128 memory)
+        returns (Fraction.Fraction256 memory)
     {
         assert(x <= NUM_PRECOMPUTED_INTEGERS);
 
-        uint128 denominator = [
+        uint256 denominator = [
             340282366920938463463374607431768211455,
             125182886983370532117250726298150828301,
             46052210507670172419625860892627118820,
@@ -272,7 +272,7 @@ library Exponent {
             11714142585413118080082437,
             4309392228124372433711936
         ][x];
-        return Fraction.Fraction128({
+        return Fraction.Fraction256({
             num: MAX_NUMERATOR,
             den: denominator
         });
@@ -283,8 +283,8 @@ library Exponent {
     function ONE()
         private
         pure
-        returns (Fraction.Fraction128 memory)
+        returns (Fraction.Fraction256 memory)
     {
-        return Fraction.Fraction128({ num: 1, den: 1 });
+        return Fraction.Fraction256({ num: 1, den: 1 });
     }
 }

--- a/contracts/lib/Fraction.sol
+++ b/contracts/lib/Fraction.sol
@@ -27,8 +27,8 @@ pragma experimental "v0.5.0";
  * This library contains implementations for fraction structs.
  */
 library Fraction {
-    struct Fraction128 {
-        uint128 num;
-        uint128 den;
+    struct Fraction256 {
+        uint256 num;
+        uint256 den;
     }
 }

--- a/contracts/lib/Math512.sol
+++ b/contracts/lib/Math512.sol
@@ -1,0 +1,154 @@
+/*
+
+    Copyright 2018 dYdX Trading Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+*/
+
+pragma solidity 0.4.24;
+pragma experimental "v0.5.0";
+
+
+/**
+ * @title Math512
+ */
+library Math512 {
+
+    /**
+     * returns 2**256 / a
+     * @param  a  The input
+     * @return    The result
+     */
+    function div256(
+        uint256 a
+    )
+        internal
+        pure
+        returns (uint256 r)
+    {
+        require(a > 1);
+        assembly {
+            r := add(div(sub(0, a), a), 1)
+        }
+    }
+
+    /**
+     * returns 2**256 mod a
+     * @param  a  The input
+     * @return    The result
+     */
+    function mod256(
+        uint256 a
+    )
+        internal
+        pure
+        returns (uint256 r)
+    {
+        require(a != 0);
+        assembly {
+            r := mod(sub(0, a), a)
+        }
+    }
+
+    function add512(
+        uint256 a0,
+        uint256 a1,
+        uint256 b0,
+        uint256 b1
+    )
+        internal
+        pure
+        returns (uint256 r0, uint256 r1)
+    {
+        assembly {
+            r0 := add(a0, b0)
+            r1 := add(add(a1, b1), lt(r0, a0))
+        }
+    }
+
+    function sub512(
+        uint256 a0,
+        uint256 a1,
+        uint256 b0,
+        uint256 b1
+    )
+        internal
+        pure
+        returns (uint256 r0, uint256 r1)
+    {
+        assert (a1 > b1 || (a1 == b1 && a0 > b0));
+        assembly {
+            r0 := sub(a0, b0)
+            r1 := sub(sub(a1, b1), lt(a0, b0))
+        }
+    }
+
+    function mul512(
+        uint256 a,
+        uint256 b
+    )
+        internal
+        pure
+        returns (uint256 r0, uint256 r1)
+    {
+        assembly {
+            let mm := mulmod(a, b, not(0))
+            r0 := mul(a, b)
+            r1 := sub(sub(mm, r0), lt(mm, r0))
+        }
+    }
+
+    function div512(
+        uint256 a0,
+        uint256 a1,
+        uint256 b
+    )
+        internal
+        pure
+        returns (uint256 x0, uint256 x1)
+    {
+        require (b != 0);
+
+        if (b == 1) {
+            return (a0, a1);
+        }
+        uint256 t0;
+        uint256 t1;
+        uint256 q = div256(b);
+        uint256 r = mod256(b);
+        while (a1 != 0) {
+            (t0, t1) = mul512(a1, q);
+            (x0, x1) = add512(x0, x1, t0, t1);
+            (t0, t1) = mul512(a1, r);
+            (a0, a1) = add512(t0, t1, a0, 0);
+        }
+        (x0, x1) = add512(x0, x1, a0 / b, 0);
+    }
+
+    function max512(
+        uint256 a0,
+        uint256 a1,
+        uint256 b0,
+        uint256 b1
+    )
+        internal
+        pure
+        returns (uint256 r0, uint256 r1)
+    {
+        if (a1 == b1) {
+            return a0 > b0 ? (a0, a1) : (b0, b1);
+        }
+        return a1 > b1 ? (a0, a1) : (b0, b1);
+    }
+}

--- a/contracts/lib/Math512.sol
+++ b/contracts/lib/Math512.sol
@@ -19,17 +19,24 @@
 pragma solidity 0.4.24;
 pragma experimental "v0.5.0";
 
+import { MathHelpers } from "./MathHelpers.sol";
+
 
 /**
  * @title Math512
+ * @author dYdX
+ *
+ * Bitwise math manipulations
  */
 library Math512 {
 
     /**
-     * returns 2**256 / a
+     * Returns 2**256 / a
+     *
      * @param  a  The input
      * @return    The result
      */
+    /* solium-disable-next-line security/no-named-returns */
     function div256(
         uint256 a
     )
@@ -38,29 +45,23 @@ library Math512 {
         returns (uint256 r)
     {
         require(a > 1);
+        /* solium-disable-next-line security/no-inline-assembly */
         assembly {
             r := add(div(sub(0, a), a), 1)
         }
     }
 
     /**
-     * returns 2**256 mod a
-     * @param  a  The input
-     * @return    The result
+     * Returns R = A + B
+     *
+     * @param  a0  The least-significant digits of A
+     * @param  a1  The least-significant digits of A
+     * @param  b0  The least-significant digits of B
+     * @param  b1  The least-significant digits of B
+     * @return     1) The least-significant digits of R
+     *             2) The most-significant digits of R
      */
-    function mod256(
-        uint256 a
-    )
-        internal
-        pure
-        returns (uint256 r)
-    {
-        require(a != 0);
-        assembly {
-            r := mod(sub(0, a), a)
-        }
-    }
-
+    /* solium-disable-next-line security/no-named-returns */
     function add512(
         uint256 a0,
         uint256 a1,
@@ -71,12 +72,24 @@ library Math512 {
         pure
         returns (uint256 r0, uint256 r1)
     {
+        /* solium-disable-next-line security/no-inline-assembly */
         assembly {
             r0 := add(a0, b0)
             r1 := add(add(a1, b1), lt(r0, a0))
         }
     }
 
+    /**
+     * Returns R = A - B
+     *
+     * @param  a0  The least-significant digits of A
+     * @param  a1  The least-significant digits of A
+     * @param  b0  The least-significant digits of B
+     * @param  b1  The least-significant digits of B
+     * @return     1) The least-significant digits of R
+     *             2) The most-significant digits of R
+     */
+    /* solium-disable-next-line security/no-named-returns */
     function sub512(
         uint256 a0,
         uint256 a1,
@@ -88,12 +101,22 @@ library Math512 {
         returns (uint256 r0, uint256 r1)
     {
         assert (a1 > b1 || (a1 == b1 && a0 > b0));
+        /* solium-disable-next-line security/no-inline-assembly */
         assembly {
             r0 := sub(a0, b0)
             r1 := sub(sub(a1, b1), lt(a0, b0))
         }
     }
 
+    /**
+     * Returns R = a * b
+     *
+     * @param  a  One input
+     * @param  b  The other input
+     * @return    1) The least-significant digits of R
+     *            2) The most-significant digits of R
+     */
+    /* solium-disable-next-line security/no-named-returns */
     function mul512(
         uint256 a,
         uint256 b
@@ -102,53 +125,11 @@ library Math512 {
         pure
         returns (uint256 r0, uint256 r1)
     {
+        /* solium-disable-next-line security/no-inline-assembly */
         assembly {
             let mm := mulmod(a, b, not(0))
             r0 := mul(a, b)
             r1 := sub(sub(mm, r0), lt(mm, r0))
         }
-    }
-
-    function div512(
-        uint256 a0,
-        uint256 a1,
-        uint256 b
-    )
-        internal
-        pure
-        returns (uint256 x0, uint256 x1)
-    {
-        require (b != 0);
-
-        if (b == 1) {
-            return (a0, a1);
-        }
-        uint256 t0;
-        uint256 t1;
-        uint256 q = div256(b);
-        uint256 r = mod256(b);
-        while (a1 != 0) {
-            (t0, t1) = mul512(a1, q);
-            (x0, x1) = add512(x0, x1, t0, t1);
-            (t0, t1) = mul512(a1, r);
-            (a0, a1) = add512(t0, t1, a0, 0);
-        }
-        (x0, x1) = add512(x0, x1, a0 / b, 0);
-    }
-
-    function max512(
-        uint256 a0,
-        uint256 a1,
-        uint256 b0,
-        uint256 b1
-    )
-        internal
-        pure
-        returns (uint256 r0, uint256 r1)
-    {
-        if (a1 == b1) {
-            return a0 > b0 ? (a0, a1) : (b0, b1);
-        }
-        return a1 > b1 ? (a0, a1) : (b0, b1);
     }
 }

--- a/contracts/lib/MathHelpers.sol
+++ b/contracts/lib/MathHelpers.sol
@@ -108,29 +108,47 @@ library MathHelpers {
     }
 
     /**
-     * Returns the number of bits in a uint256. That is, the lowest number, x, such that n >> x == 0
+     * Returns the number of bits in a uint256. That is, the lowest number, y, such that x >> y == 0
      *
-     * @param  n  The uint256 to get the number of bits in
-     * @return    The number of bits in n
+     * @param  x  The uint256 to get the number of bits in
+     * @return    The number of bits in x
      */
     function getNumBits(
+        uint256 x
+    )
+        internal
+        pure
+        returns (uint256)
+    {
+        uint256 y;
+        uint256 n = 0;
+        y = x >>128; if (y != 0) { n += 128; x = y; }
+        y = x >> 64; if (y != 0) { n +=  64; x = y; }
+        y = x >> 32; if (y != 0) { n +=  32; x = y; }
+        y = x >> 16; if (y != 0) { n +=  16; x = y; }
+        y = x >>  8; if (y != 0) { n +=   8; x = y; }
+        y = x >>  4; if (y != 0) { n +=   4; x = y; }
+        y = x >>  2; if (y != 0) { n +=   2; x = y; }
+        y = x >>  1; if (y != 0) return n + 2;
+        return n + x;
+    }
+
+    function getHighestBit(
         uint256 n
     )
         internal
         pure
         returns (uint256)
     {
-        uint256 first = 0;
-        uint256 last = 256;
-        while (first < last) {
-            uint256 check = (first + last) / 2;
-            if ((n >> check) == 0) {
-                last = check;
-            } else {
-                first = check + 1;
-            }
-        }
-        assert(first <= 256);
-        return first;
+        uint256 m = n;
+        m |= m >> 1;
+        m |= m >> 2;
+        m |= m >> 4;
+        m |= m >> 8;
+        m |= m >> 16;
+        m |= m >> 32;
+        m |= m >> 64;
+        m |= m >> 128;
+        return m + 1;
     }
 }

--- a/contracts/testing/TestExponent.sol
+++ b/contracts/testing/TestExponent.sol
@@ -28,8 +28,8 @@ import { MathHelpers } from "../lib/MathHelpers.sol";
 
 contract TestExponent {
     function exp(
-        uint128 numerator,
-        uint128 denominator,
+        uint256 numerator,
+        uint256 denominator,
         uint256 precomputePrecision,
         uint256 maclaurinPrecision
     )
@@ -37,8 +37,8 @@ contract TestExponent {
         pure
         returns (uint256, uint256)
     {
-        Fraction.Fraction128 memory percent = Exponent.exp(
-            Fraction.Fraction128({
+        Fraction.Fraction256 memory percent = Exponent.exp(
+            Fraction.Fraction256({
                 num: numerator,
                 den: denominator
             }),

--- a/contracts/testing/TestFractionMath.sol
+++ b/contracts/testing/TestFractionMath.sol
@@ -27,17 +27,17 @@ contract TestFractionMath {
     using FractionMath for Fraction.Fraction256;
 
     function add(
-        uint256 a,
-        uint256 b,
-        uint256 c,
-        uint256 d
+        uint256 n1,
+        uint256 d1,
+        uint256 n2,
+        uint256 d2
     )
         external
         pure
         returns (uint256, uint256)
     {
-        Fraction.Fraction256 memory p = Fraction.Fraction256({num: a, den: b});
-        Fraction.Fraction256 memory q = Fraction.Fraction256({num: c, den: d});
+        Fraction.Fraction256 memory p = Fraction.Fraction256({num: n1, den: d1});
+        Fraction.Fraction256 memory q = Fraction.Fraction256({num: n2, den: d2});
         Fraction.Fraction256 memory r = p.add(q);
         return (r.num, r.den);
     }

--- a/contracts/testing/TestFractionMath.sol
+++ b/contracts/testing/TestFractionMath.sol
@@ -24,90 +24,92 @@ import { FractionMath } from "../lib/FractionMath.sol";
 
 
 contract TestFractionMath {
-    using FractionMath for Fraction.Fraction128;
+    using FractionMath for Fraction.Fraction256;
 
     function add(
-        uint128 a,
-        uint128 b,
-        uint128 c,
-        uint128 d
+        uint256 a,
+        uint256 b,
+        uint256 c,
+        uint256 d
     )
         external
         pure
-        returns (uint128, uint128)
+        returns (uint256, uint256)
     {
-        Fraction.Fraction128 memory p = Fraction.Fraction128({num: a, den: b});
-        Fraction.Fraction128 memory q = Fraction.Fraction128({num: c, den: d});
-        Fraction.Fraction128 memory r = p.add(q);
+        Fraction.Fraction256 memory p = Fraction.Fraction256({num: a, den: b});
+        Fraction.Fraction256 memory q = Fraction.Fraction256({num: c, den: d});
+        Fraction.Fraction256 memory r = p.add(q);
         return (r.num, r.den);
     }
 
     function sub1Over(
-        uint128 a,
-        uint128 b,
-        uint128 d
+        uint256 a,
+        uint256 b,
+        uint256 d
     )
         external
         pure
-        returns (uint128, uint128)
+        returns (uint256, uint256)
     {
-        Fraction.Fraction128 memory p = Fraction.Fraction128({num: a, den: b});
-        Fraction.Fraction128 memory r = p.sub1Over(d);
+        Fraction.Fraction256 memory p = Fraction.Fraction256({num: a, den: b});
+        Fraction.Fraction256 memory r = p.sub1Over(d);
         return (r.num, r.den);
     }
 
     function div(
-        uint128 a,
-        uint128 b,
-        uint128 d
+        uint256 a,
+        uint256 b,
+        uint256 d
     )
         external
         pure
-        returns (uint128, uint128)
+        returns (uint256, uint256)
     {
-        Fraction.Fraction128 memory p = Fraction.Fraction128({num: a, den: b});
-        Fraction.Fraction128 memory r = p.div(d);
+        Fraction.Fraction256 memory p = Fraction.Fraction256({num: a, den: b});
+        Fraction.Fraction256 memory r = p.div(d);
         return (r.num, r.den);
     }
 
     function mul(
-        uint128 a,
-        uint128 b,
-        uint128 c,
-        uint128 d
+        uint256 a,
+        uint256 b,
+        uint256 c,
+        uint256 d
     )
         external
         pure
-        returns (uint128, uint128)
+        returns (uint256, uint256)
     {
-        Fraction.Fraction128 memory p = Fraction.Fraction128({num: a, den: b});
-        Fraction.Fraction128 memory q = Fraction.Fraction128({num: c, den: d});
-        Fraction.Fraction128 memory r = p.mul(q);
+        Fraction.Fraction256 memory p = Fraction.Fraction256({num: a, den: b});
+        Fraction.Fraction256 memory q = Fraction.Fraction256({num: c, den: d});
+        Fraction.Fraction256 memory r = p.mul(q);
         return (r.num, r.den);
     }
 
     function bound(
+        uint256 n0,
+        uint256 n1,
+        uint256 d0,
+        uint256 d1
+    )
+        external
+        pure
+        returns (uint256, uint256)
+    {
+        Fraction.Fraction256 memory r = FractionMath.bound(n0, n1, d0, d1);
+        return (r.num, r.den);
+    }
+
+    function copy(
         uint256 a,
         uint256 b
     )
         external
         pure
-        returns (uint128, uint128)
+        returns (uint256, uint256)
     {
-        Fraction.Fraction128 memory r = FractionMath.bound(a, b);
-        return (r.num, r.den);
-    }
-
-    function copy(
-        uint128 a,
-        uint128 b
-    )
-        external
-        pure
-        returns (uint128, uint128)
-    {
-        Fraction.Fraction128 memory p = Fraction.Fraction128({num: a, den: b});
-        Fraction.Fraction128 memory r = p.copy();
+        Fraction.Fraction256 memory p = Fraction.Fraction256({num: a, den: b});
+        Fraction.Fraction256 memory r = p.copy();
         return (r.num, r.den);
     }
 }

--- a/contracts/testing/TestInterestImpl.sol
+++ b/contracts/testing/TestInterestImpl.sol
@@ -46,4 +46,12 @@ contract TestInterestImpl {
             secondsOfInterest
         );
     }
+
+    function doNothing()
+        public
+    {
+        if (false) {
+            test = 1;
+        }
+    }
 }

--- a/contracts/testing/TestMath512.sol
+++ b/contracts/testing/TestMath512.sol
@@ -1,0 +1,27 @@
+/*
+
+    Copyright 2018 dYdX Trading Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+*/
+
+pragma solidity 0.4.24;
+pragma experimental "v0.5.0";
+
+import { Math512 } from "../lib/Math512.sol";
+
+
+contract TestMath512 {
+
+}

--- a/contracts/testing/TestMathHelpers.sol
+++ b/contracts/testing/TestMathHelpers.sol
@@ -77,4 +77,14 @@ contract TestMathHelpers {
     {
         return MathHelpers.getNumBits(n);
     }
+
+    function getHighestBit(
+        uint256 n
+    )
+        public
+        pure
+        returns (uint256)
+    {
+        return MathHelpers.getHighestBit(n);
+    }
 }

--- a/test/margin/TestFractionMath.js
+++ b/test/margin/TestFractionMath.js
@@ -18,10 +18,15 @@ contract('FractionMath', function(_accounts) {
   // ============ add ============
 
   describe('#add', () => {
-    it('succeeds for addition overflow', async () => {
-      const [num, den] = await contract.add(bn, bn, bn, bn);
-      console.log(num, den);
-      expect(num).to.be.bignumber.equal(den.times(2));
+    async function add(n1, d1, n2, d2, numRes, denRes) {
+      const result = await contract.add(n1, d1, n2, d2);
+      expect(result[0]).to.be.bignumber.equal(numRes);
+      expect(result[1]).to.be.bignumber.equal(denRes);
+    }
+    it('succeeds for add', async () => {
+      await Promise.all([
+        add(1, 2, 1, 2, 2, 2)
+      ]);
     });
   });
 

--- a/test/margin/TestFractionMath.js
+++ b/test/margin/TestFractionMath.js
@@ -6,7 +6,7 @@ const TestFractionMath = artifacts.require("TestFractionMath");
 const { BIGNUMBERS } = require('../helpers/Constants');
 const { expectAssertFailure } = require('../helpers/ExpectHelper');
 
-const bn = BIGNUMBERS.ONES_127;
+const bn = BIGNUMBERS.ONES_255;
 
 contract('FractionMath', function(_accounts) {
   let contract;
@@ -20,6 +20,7 @@ contract('FractionMath', function(_accounts) {
   describe('#add', () => {
     it('succeeds for addition overflow', async () => {
       const [num, den] = await contract.add(bn, bn, bn, bn);
+      console.log(num, den);
       expect(num).to.be.bignumber.equal(den.times(2));
     });
   });
@@ -124,35 +125,35 @@ contract('FractionMath', function(_accounts) {
   // ============ bound ============
 
   describe('#bound', () => {
-    async function bound(num, den, numRes, denRes) {
-      const result = await contract.bound(num, den);
+    async function bound(n0, n1, d0, d1, numRes, denRes) {
+      const result = await contract.bound(n0, n1, d0, d1);
       expect(result[0]).to.be.bignumber.equal(numRes);
       expect(result[1]).to.be.bignumber.equal(denRes);
     }
 
-    async function boundThrow(num, den) {
-      await expectAssertFailure(contract.bound(num, den));
+    async function boundThrow(n0, n1, d0, d1) {
+      await expectAssertFailure(contract.bound(n0, n1, d0, d1));
     }
 
     it('succeeds for most values', async () => {
       await Promise.all([
-        bound(0, 1, 0, 1),
-        bound(1, 1, 1, 1),
-        bound(2, 4, 2, 4),
-        bound(bn, 1, bn, 1),
-        bound(0, bn, 0, bn),
-        bound(bn, bn, bn, bn),
-        bound(bn.times(2), bn, bn, bn.div(2).floor()),
+        bound(0, 0, 1, 0, 0, 1),
+        bound(1, 0, 1, 0, 1, 1),
+        bound(2, 0, 4, 0, 2, 4),
+        bound(bn, 0, 1, 0, bn, 1),
+        bound(0, 0, bn, 0, 0, bn),
+        bound(bn, 0, bn, 0, bn, bn),
+        bound(bn.times(2), 0, bn, 0, bn, bn.div(2).floor()),
       ]);
     });
 
     it('fails for zero denominator', async () => {
       await Promise.all([
-        boundThrow(0, 0),
-        boundThrow(1, 0),
-        boundThrow(bn, 0),
-        boundThrow(bn.times(2), 1),
-        boundThrow(bn.times(10), 2),
+        boundThrow(0, 0, 0, 0),
+        boundThrow(1, 0, 0, 0),
+        boundThrow(bn, 0, 0, 0),
+        boundThrow(bn.times(2), 0, 1, 0),
+        boundThrow(bn.times(10), 0, 2, 0),
       ]);
     });
   });

--- a/test/margin/TestMath512.js
+++ b/test/margin/TestMath512.js
@@ -1,0 +1,17 @@
+const chai = require('chai');
+const expect = chai.expect;
+chai.use(require('chai-bignumber')());
+
+const BigNumber = require('bignumber.js');
+
+const TestMath512 = artifacts.require("TestMath512");
+const { BIGNUMBERS } = require('../helpers/Constants');
+const { expectAssertFailure } = require('../helpers/ExpectHelper');
+
+contract('InterestHelper', function(_accounts) {
+  let contract;
+
+  before('set up contract', async () => {
+    contract = await TestMath512.new();
+  });
+});

--- a/test/margin/TestMathHelpers.js
+++ b/test/margin/TestMathHelpers.js
@@ -131,10 +131,18 @@ contract('InterestHelper', function(_accounts) {
       expect(result).to.be.bignumber.equal(0);
 
       let n = new BigNumber(1);
+      let m = new BigNumber(1);
       for(let i = 0; i < 256; i++) {
-        let result = await contract.getNumBits.call(n);
-        expect(result).to.be.bignumber.equal(i + 1);
+        let [result0, result1] = await Promise.all([
+          contract.getNumBits.call(n),
+          contract.getNumBits.call(m)
+        ]);
+
+        expect(result0).to.be.bignumber.equal(i + 1);
+        expect(result1).to.be.bignumber.equal(i + 1);
+
         n = n.times(2);
+        m = m.plus(n);
       }
     });
   });

--- a/util/DeployGasCosts.js
+++ b/util/DeployGasCosts.js
@@ -71,14 +71,17 @@ contract('Deploy Costs', () => {
       const tokens2 = new BigNumber('1e40');
       const percent = new BigNumber('1e6');
 
+      let gasCostBase = await contract.doNothing();
+      gasCostBase = gasCostBase.receipt.gasUsed;
+
       async function printGasCost(seconds) {
         const tx = await contract.getCompoundedInterest(tokens1, percent, seconds);
-        console.log('\tInterestCalculation gas cost (small): ' + tx.receipt.gasUsed);
+        console.log('\tInterestCalculation gas cost (sml): ' + (tx.receipt.gasUsed - gasCostBase));
       }
 
       async function printGasCostLarge(seconds) {
         const tx = await contract.getCompoundedInterest(tokens2, percent, seconds);
-        console.log('\tInterestCalculation gas cost (large): ' + tx.receipt.gasUsed);
+        console.log('\tInterestCalculation gas cost (lrg): ' + (tx.receipt.gasUsed - gasCostBase));
       }
 
       await printGasCost(new BigNumber(BIGNUMBERS.ONE_DAY_IN_SECONDS));


### PR DESCRIPTION
BEFORE:
```
    InterestImpl
	InterestCalculation gas cost (small): 47039 (25659 pure)
	InterestCalculation gas cost (small): 47039
	InterestCalculation gas cost (small): 52391
	InterestCalculation gas cost (small): 52455
	InterestCalculation gas cost (large): 49777
	InterestCalculation gas cost (large): 55193 (33813 pure)
```
AFTER:
```    InterestImpl
	InterestCalculation gas cost (small): 43381 (22001 pure)
	InterestCalculation gas cost (small): 43381
	InterestCalculation gas cost (small): 47650
	InterestCalculation gas cost (small): 47714
	InterestCalculation gas cost (large): 44989
	InterestCalculation gas cost (large): 49322 (27942 pure)
```