### PR TITLE
Save gas, add no_ouput_timeout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,6 +57,7 @@ jobs:
       - run:
           name: Test
           command: TESTFILES=$(circleci tests glob "test/**/*.js" | circleci tests split --split-by=timings) && TRUFFLE_REPORTER=true npm test -- ${TESTFILES}
+          no_output_timeout: 20m
       - store_test_results:
           path: ~/protocol/junit
       - store_artifacts:
@@ -71,6 +72,7 @@ jobs:
       - run:
           name: Coverage
           command: python util/hideasserts.py && npm run coverage && cat coverage/lcov.info | node_modules/.bin/coveralls
+          no_output_timeout: 40m
 
 workflows:
   version: 2

--- a/contracts/lib/FractionMath.sol
+++ b/contracts/lib/FractionMath.sol
@@ -162,8 +162,8 @@ library FractionMath {
         }
 
         assert(den != 0); // unit-tested
-        assert(den < 2**128); // unit-tested
-        assert(num < 2**128); // unit-tested
+        assert(den < 2**128);
+        assert(num < 2**128);
 
         return Fraction.Fraction128({
             num: uint128(num),

--- a/contracts/lib/FractionMath.sol
+++ b/contracts/lib/FractionMath.sol
@@ -161,7 +161,9 @@ library FractionMath {
             den /= first128Bits;
         }
 
-        assert(den != 0 && den < 2**128 && num < 2**128); // unit-tested
+        assert(den != 0); // unit-tested
+        assert(den < 2**128); // unit-tested
+        assert(num < 2**128); // unit-tested
 
         return Fraction.Fraction128({
             num: uint128(num),


### PR DESCRIPTION
assert changes saves about 400 gas (~2%) on the interest rate calculation