### PR TITLE
Update web3, explicitly include websocket

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1904,14 +1904,15 @@
       }
     },
     "browserify-des": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.1.tgz",
-      "integrity": "sha512-zy0Cobe3hhgpiOM32Tj7KQ3Vl91m0njwsjzZQK1L+JDf11dzP9qIvjreVinsvXrgfjhStXwUWAEpB9D7Gwmayw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
+      "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
       "dev": true,
       "requires": {
         "cipher-base": "^1.0.1",
         "des.js": "^1.0.0",
-        "inherits": "^2.0.1"
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
       }
     },
     "browserify-rsa": {
@@ -1967,9 +1968,9 @@
       }
     },
     "buffer": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.1.0.tgz",
-      "integrity": "sha512-YkIRgwsZwJWTnyQrsBTWefizHh+8GYj3kbL1BTiAQ/9pwpino0G7B2gp5tx/FUBqUlvtxV85KNR3mwfAtv15Yw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.0.tgz",
+      "integrity": "sha512-nUJyfChH7PMJy75eRDCCKtszSEFokUNXC1hNVSe+o+VdcgvDPLs20k3v8UXI8ruRYAJiYtyRea8mYyqPxoHWDw==",
       "dev": true,
       "requires": {
         "base64-js": "^1.0.2",
@@ -2511,6 +2512,12 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
+      "dev": true
+    },
+    "cookiejar": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
+      "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==",
       "dev": true
     },
     "copy-descriptor": {
@@ -5471,9 +5478,9 @@
       }
     },
     "ieee754": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.11.tgz",
-      "integrity": "sha512-VhDzCKN7K8ufStx/CLj5/PDTMgph+qwN5Pkd5i0sGnVwk56zJ0lkT8Qzi1xqWLS0Wp29DgDtNeS7v8/wMoZeHg==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.12.tgz",
+      "integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA==",
       "dev": true
     },
     "ignore": {
@@ -5635,9 +5642,9 @@
       "dev": true
     },
     "ipaddr.js": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.6.0.tgz",
-      "integrity": "sha1-4/o1e3c9phnybpXwSdBVxyeW+Gs=",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.8.0.tgz",
+      "integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4=",
       "dev": true
     },
     "is-accessor-descriptor": {
@@ -5680,9 +5687,9 @@
       }
     },
     "is-callable": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
-      "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
       "dev": true
     },
     "is-data-descriptor": {
@@ -7822,13 +7829,13 @@
       "dev": true
     },
     "proxy-addr": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.3.tgz",
-      "integrity": "sha512-jQTChiCJteusULxjBp8+jftSQE5Obdl3k4cnmLA6WXtK6XFuWRnvVL7aCiBqaLPM8c4ph0S4tKna8XvmIwEnXQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.4.tgz",
+      "integrity": "sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==",
       "dev": true,
       "requires": {
         "forwarded": "~0.1.2",
-        "ipaddr.js": "1.6.0"
+        "ipaddr.js": "1.8.0"
       }
     },
     "prr": {
@@ -10297,24 +10304,24 @@
       }
     },
     "web3": {
-      "version": "1.0.0-beta.34",
-      "resolved": "https://registry.npmjs.org/web3/-/web3-1.0.0-beta.34.tgz",
-      "integrity": "sha1-NH5WG3hAmMtVYzFfSQR5odkfKrE=",
+      "version": "1.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/web3/-/web3-1.0.0-beta.35.tgz",
+      "integrity": "sha512-xwDmUhvTcHQvvNnOPcPZZgCxKUsI2e+GbHy7JkTK3/Rmnutazy8x7fsAXT9myw7V1qpi3GgLoZ3fkglSUbg1Mg==",
       "dev": true,
       "requires": {
-        "web3-bzz": "1.0.0-beta.34",
-        "web3-core": "1.0.0-beta.34",
-        "web3-eth": "1.0.0-beta.34",
-        "web3-eth-personal": "1.0.0-beta.34",
-        "web3-net": "1.0.0-beta.34",
-        "web3-shh": "1.0.0-beta.34",
-        "web3-utils": "1.0.0-beta.34"
+        "web3-bzz": "1.0.0-beta.35",
+        "web3-core": "1.0.0-beta.35",
+        "web3-eth": "1.0.0-beta.35",
+        "web3-eth-personal": "1.0.0-beta.35",
+        "web3-net": "1.0.0-beta.35",
+        "web3-shh": "1.0.0-beta.35",
+        "web3-utils": "1.0.0-beta.35"
       }
     },
     "web3-bzz": {
-      "version": "1.0.0-beta.34",
-      "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.0.0-beta.34.tgz",
-      "integrity": "sha1-Bo03d3q2Xlxg+OyLmlDP5FJ3kpw=",
+      "version": "1.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.0.0-beta.35.tgz",
+      "integrity": "sha512-BhAU0qhlr8zltm4gs/+P1gki2VkxHJaM2Rrh4DGesDW0lzwufRoNvWFlwx1bKHoFPWNbSmm9PRkHOYOINL/Tgw==",
       "dev": true,
       "requires": {
         "got": "7.1.0",
@@ -10383,26 +10390,26 @@
       }
     },
     "web3-core": {
-      "version": "1.0.0-beta.34",
-      "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.0.0-beta.34.tgz",
-      "integrity": "sha1-EhvoVV6fsA0sXQXd0zgdDJ5GmH4=",
+      "version": "1.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.0.0-beta.35.tgz",
+      "integrity": "sha512-ayGavbgVk4KL9Y88Uv411fBJ0SVgVfKhKEBweKYzmP0zOqneMzWt6YsyD1n6kRvjAbqA0AfUPEOKyMNjcx2tjw==",
       "dev": true,
       "requires": {
-        "web3-core-helpers": "1.0.0-beta.34",
-        "web3-core-method": "1.0.0-beta.34",
-        "web3-core-requestmanager": "1.0.0-beta.34",
-        "web3-utils": "1.0.0-beta.34"
+        "web3-core-helpers": "1.0.0-beta.35",
+        "web3-core-method": "1.0.0-beta.35",
+        "web3-core-requestmanager": "1.0.0-beta.35",
+        "web3-utils": "1.0.0-beta.35"
       }
     },
     "web3-core-helpers": {
-      "version": "1.0.0-beta.34",
-      "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.0.0-beta.34.tgz",
-      "integrity": "sha1-sWjaANPhnhVrwVriAyA91N/uLQM=",
+      "version": "1.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.0.0-beta.35.tgz",
+      "integrity": "sha512-APOu3sEsamyqWt//8o4yq9KF25/uqGm+pQShson/sC4gKzmfJB07fLo2ond0X30E8fIqAPeVCotPXQxGciGUmA==",
       "dev": true,
       "requires": {
         "underscore": "1.8.3",
-        "web3-eth-iban": "1.0.0-beta.34",
-        "web3-utils": "1.0.0-beta.34"
+        "web3-eth-iban": "1.0.0-beta.35",
+        "web3-utils": "1.0.0-beta.35"
       },
       "dependencies": {
         "underscore": {
@@ -10414,16 +10421,16 @@
       }
     },
     "web3-core-method": {
-      "version": "1.0.0-beta.34",
-      "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.0.0-beta.34.tgz",
-      "integrity": "sha1-7BY8iixJD6AqfsFVWfpzB/x8xt0=",
+      "version": "1.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.0.0-beta.35.tgz",
+      "integrity": "sha512-jidImCide8q0GpfsO4L73qoHrbkeWgwU3uOH5DKtJtv0ccmG086knNMRgryb/o9ZgetDWLmDEsJnHjBSoIwcbA==",
       "dev": true,
       "requires": {
         "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.34",
-        "web3-core-promievent": "1.0.0-beta.34",
-        "web3-core-subscriptions": "1.0.0-beta.34",
-        "web3-utils": "1.0.0-beta.34"
+        "web3-core-helpers": "1.0.0-beta.35",
+        "web3-core-promievent": "1.0.0-beta.35",
+        "web3-core-subscriptions": "1.0.0-beta.35",
+        "web3-utils": "1.0.0-beta.35"
       },
       "dependencies": {
         "underscore": {
@@ -10435,9 +10442,9 @@
       }
     },
     "web3-core-promievent": {
-      "version": "1.0.0-beta.34",
-      "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.0.0-beta.34.tgz",
-      "integrity": "sha1-pPT6Z4S7KT6CxglgrltWqUzQPtw=",
+      "version": "1.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.0.0-beta.35.tgz",
+      "integrity": "sha512-GvqXqKq07OmHuVi5uNRg6k79a1/CI0ViCC+EtNv4CORHtDRmYEt5Bvdv6z6FJEiaaQkD0lKbFwNhLxutx7HItw==",
       "dev": true,
       "requires": {
         "any-promise": "1.3.0",
@@ -10445,16 +10452,16 @@
       }
     },
     "web3-core-requestmanager": {
-      "version": "1.0.0-beta.34",
-      "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.0.0-beta.34.tgz",
-      "integrity": "sha1-Afj2zyrmtvC3DDi64e90G1urIVw=",
+      "version": "1.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.0.0-beta.35.tgz",
+      "integrity": "sha512-S+zW2h17ZZQU9oe3yaCJE0E7aJS4C3Kf4kGPDv+nXjW0gKhQQhgVhw1Doq/aYQGqNSWJp7f1VHkz5gQWwg6RRg==",
       "dev": true,
       "requires": {
         "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.34",
-        "web3-providers-http": "1.0.0-beta.34",
-        "web3-providers-ipc": "1.0.0-beta.34",
-        "web3-providers-ws": "1.0.0-beta.34"
+        "web3-core-helpers": "1.0.0-beta.35",
+        "web3-providers-http": "1.0.0-beta.35",
+        "web3-providers-ipc": "1.0.0-beta.35",
+        "web3-providers-ws": "1.0.0-beta.35"
       },
       "dependencies": {
         "underscore": {
@@ -10466,14 +10473,14 @@
       }
     },
     "web3-core-subscriptions": {
-      "version": "1.0.0-beta.34",
-      "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.0.0-beta.34.tgz",
-      "integrity": "sha1-n+0UQDPyIcPPIQYDAv/a9e8t4t4=",
+      "version": "1.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.0.0-beta.35.tgz",
+      "integrity": "sha512-gXzLrWvcGkGiWq1y33Z4Y80XI8XMrwowiQJkrPSjQ81K5PBKquOGwcMffLaKcwdmEy/NpsOXDeFo3eLE1Ghvvw==",
       "dev": true,
       "requires": {
         "eventemitter3": "1.1.1",
         "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.34"
+        "web3-core-helpers": "1.0.0-beta.35"
       },
       "dependencies": {
         "underscore": {
@@ -10485,23 +10492,23 @@
       }
     },
     "web3-eth": {
-      "version": "1.0.0-beta.34",
-      "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.0.0-beta.34.tgz",
-      "integrity": "sha1-dAhgAIUMb+b1Ne9Jg31tS7YRMmg=",
+      "version": "1.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.0.0-beta.35.tgz",
+      "integrity": "sha512-04mcb2nGPXThawuuYICPOxv0xOHofvQKsjZeIq+89nyOC8DQMGTAErDkGyMHQYtjpth5XDhic0wuEsA80AmFZA==",
       "dev": true,
       "requires": {
         "underscore": "1.8.3",
-        "web3-core": "1.0.0-beta.34",
-        "web3-core-helpers": "1.0.0-beta.34",
-        "web3-core-method": "1.0.0-beta.34",
-        "web3-core-subscriptions": "1.0.0-beta.34",
-        "web3-eth-abi": "1.0.0-beta.34",
-        "web3-eth-accounts": "1.0.0-beta.34",
-        "web3-eth-contract": "1.0.0-beta.34",
-        "web3-eth-iban": "1.0.0-beta.34",
-        "web3-eth-personal": "1.0.0-beta.34",
-        "web3-net": "1.0.0-beta.34",
-        "web3-utils": "1.0.0-beta.34"
+        "web3-core": "1.0.0-beta.35",
+        "web3-core-helpers": "1.0.0-beta.35",
+        "web3-core-method": "1.0.0-beta.35",
+        "web3-core-subscriptions": "1.0.0-beta.35",
+        "web3-eth-abi": "1.0.0-beta.35",
+        "web3-eth-accounts": "1.0.0-beta.35",
+        "web3-eth-contract": "1.0.0-beta.35",
+        "web3-eth-iban": "1.0.0-beta.35",
+        "web3-eth-personal": "1.0.0-beta.35",
+        "web3-net": "1.0.0-beta.35",
+        "web3-utils": "1.0.0-beta.35"
       },
       "dependencies": {
         "underscore": {
@@ -10513,15 +10520,15 @@
       }
     },
     "web3-eth-abi": {
-      "version": "1.0.0-beta.34",
-      "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.0.0-beta.34.tgz",
-      "integrity": "sha1-A0Uz46ovfln/MXk+rqaFwO1a9no=",
+      "version": "1.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.0.0-beta.35.tgz",
+      "integrity": "sha512-KUDC+EtFFYG8z01ZleKrASdjj327/rtWHzEt6RWsEj7bBa0bGp9nEh+nqdZx/Sdgz1O8tnfFzJlrRcXpfr1vGg==",
       "dev": true,
       "requires": {
         "bn.js": "4.11.6",
         "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.34",
-        "web3-utils": "1.0.0-beta.34"
+        "web3-core-helpers": "1.0.0-beta.35",
+        "web3-utils": "1.0.0-beta.35"
       },
       "dependencies": {
         "bn.js": {
@@ -10539,9 +10546,9 @@
       }
     },
     "web3-eth-accounts": {
-      "version": "1.0.0-beta.34",
-      "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.0.0-beta.34.tgz",
-      "integrity": "sha1-4JFC7uzHl6w0WbdemyOUbTaV8zM=",
+      "version": "1.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.0.0-beta.35.tgz",
+      "integrity": "sha512-duIgRsfht/0kAW/eQ0X9lKtVIykbETrnM2H7EnvplCzPHtQLodpib4o9JXfh9n6ZDgdDC7cuJoiVB9QJg089ew==",
       "dev": true,
       "requires": {
         "any-promise": "1.3.0",
@@ -10550,10 +10557,10 @@
         "scrypt.js": "0.2.0",
         "underscore": "1.8.3",
         "uuid": "2.0.1",
-        "web3-core": "1.0.0-beta.34",
-        "web3-core-helpers": "1.0.0-beta.34",
-        "web3-core-method": "1.0.0-beta.34",
-        "web3-utils": "1.0.0-beta.34"
+        "web3-core": "1.0.0-beta.35",
+        "web3-core-helpers": "1.0.0-beta.35",
+        "web3-core-method": "1.0.0-beta.35",
+        "web3-utils": "1.0.0-beta.35"
       },
       "dependencies": {
         "elliptic": {
@@ -10597,19 +10604,19 @@
       }
     },
     "web3-eth-contract": {
-      "version": "1.0.0-beta.34",
-      "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.0.0-beta.34.tgz",
-      "integrity": "sha1-nbs4+udkOoCEJ6IBgEcOx0FckeY=",
+      "version": "1.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.0.0-beta.35.tgz",
+      "integrity": "sha512-foPohOg5O1UCGKGZOIs+kQK5IZdV2QQ7pAWwNxH8WHplUA+fre1MurXNpoxknUmH6mYplFhXjqgYq2MsrBpHrA==",
       "dev": true,
       "requires": {
         "underscore": "1.8.3",
-        "web3-core": "1.0.0-beta.34",
-        "web3-core-helpers": "1.0.0-beta.34",
-        "web3-core-method": "1.0.0-beta.34",
-        "web3-core-promievent": "1.0.0-beta.34",
-        "web3-core-subscriptions": "1.0.0-beta.34",
-        "web3-eth-abi": "1.0.0-beta.34",
-        "web3-utils": "1.0.0-beta.34"
+        "web3-core": "1.0.0-beta.35",
+        "web3-core-helpers": "1.0.0-beta.35",
+        "web3-core-method": "1.0.0-beta.35",
+        "web3-core-promievent": "1.0.0-beta.35",
+        "web3-core-subscriptions": "1.0.0-beta.35",
+        "web3-eth-abi": "1.0.0-beta.35",
+        "web3-utils": "1.0.0-beta.35"
       },
       "dependencies": {
         "underscore": {
@@ -10621,13 +10628,13 @@
       }
     },
     "web3-eth-iban": {
-      "version": "1.0.0-beta.34",
-      "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.0.0-beta.34.tgz",
-      "integrity": "sha1-mvRYYFhnzPdOqXmq8yazi6alugw=",
+      "version": "1.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.0.0-beta.35.tgz",
+      "integrity": "sha512-H5wkcNcAIc+h/WoDIKv7ZYmrM2Xqu3O7jBQl1IWo73EDVQji+AoB2i3J8tuwI1yZRInRwrfpI3Zuwuf54hXHmQ==",
       "dev": true,
       "requires": {
         "bn.js": "4.11.6",
-        "web3-utils": "1.0.0-beta.34"
+        "web3-utils": "1.0.0-beta.35"
       },
       "dependencies": {
         "bn.js": {
@@ -10639,48 +10646,48 @@
       }
     },
     "web3-eth-personal": {
-      "version": "1.0.0-beta.34",
-      "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.0.0-beta.34.tgz",
-      "integrity": "sha1-mvuhZzQuveVCC81YlcP2w0OI8gU=",
+      "version": "1.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.0.0-beta.35.tgz",
+      "integrity": "sha512-AcM9nnlxu7ZRRxPvkrFB9eLxMM4A2cPfj2aCg21Wb2EpMnhR+b/O1cT33k7ApRowoMpM+T9M8vx2oPNwXfaCOQ==",
       "dev": true,
       "requires": {
-        "web3-core": "1.0.0-beta.34",
-        "web3-core-helpers": "1.0.0-beta.34",
-        "web3-core-method": "1.0.0-beta.34",
-        "web3-net": "1.0.0-beta.34",
-        "web3-utils": "1.0.0-beta.34"
+        "web3-core": "1.0.0-beta.35",
+        "web3-core-helpers": "1.0.0-beta.35",
+        "web3-core-method": "1.0.0-beta.35",
+        "web3-net": "1.0.0-beta.35",
+        "web3-utils": "1.0.0-beta.35"
       }
     },
     "web3-net": {
-      "version": "1.0.0-beta.34",
-      "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.0.0-beta.34.tgz",
-      "integrity": "sha1-QnzqL0MYgUScjjjVIykPFz+f9j0=",
+      "version": "1.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.0.0-beta.35.tgz",
+      "integrity": "sha512-bbwaQ/KohGjIJ6HAKbZ6KrklCAaG6/B7hIbAbVLSFLxF+Yz9lmAgQYaDInpidpC/NLb3WOmcbRF+P77J4qMVIA==",
       "dev": true,
       "requires": {
-        "web3-core": "1.0.0-beta.34",
-        "web3-core-method": "1.0.0-beta.34",
-        "web3-utils": "1.0.0-beta.34"
+        "web3-core": "1.0.0-beta.35",
+        "web3-core-method": "1.0.0-beta.35",
+        "web3-utils": "1.0.0-beta.35"
       }
     },
     "web3-providers-http": {
-      "version": "1.0.0-beta.34",
-      "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.0.0-beta.34.tgz",
-      "integrity": "sha1-5WG1K7tDdmKCAH1AKFv+NVDCfno=",
+      "version": "1.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.0.0-beta.35.tgz",
+      "integrity": "sha512-DcIMFq52Fb08UpWyZ3ZlES6NsNqJnco4hBS/Ej6eOcASfuUayPI+GLkYVZsnF3cBYqlH+DOKuArcKSuIxK7jIA==",
       "dev": true,
       "requires": {
-        "web3-core-helpers": "1.0.0-beta.34",
-        "xhr2": "0.1.4"
+        "web3-core-helpers": "1.0.0-beta.35",
+        "xhr2-cookies": "1.1.0"
       }
     },
     "web3-providers-ipc": {
-      "version": "1.0.0-beta.34",
-      "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.0.0-beta.34.tgz",
-      "integrity": "sha1-obd/GjBtc2SanAOQUuQMtxMo0Ao=",
+      "version": "1.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.0.0-beta.35.tgz",
+      "integrity": "sha512-iB0FG0HcpUnayfa8pn4guqEQ4Y1nrroi/jffdtQgFkrNt0sD3fMSwwC0AbmECqj3tDLl0e1slBR0RENll+ZF0g==",
       "dev": true,
       "requires": {
         "oboe": "2.1.3",
         "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.34"
+        "web3-core-helpers": "1.0.0-beta.35"
       },
       "dependencies": {
         "underscore": {
@@ -10692,14 +10699,14 @@
       }
     },
     "web3-providers-ws": {
-      "version": "1.0.0-beta.34",
-      "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.0.0-beta.34.tgz",
-      "integrity": "sha1-fecPG4Py3jZHZ3IVa+z+9uNRbrM=",
+      "version": "1.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.0.0-beta.35.tgz",
+      "integrity": "sha512-Cx64NgDStynKaUGDIIOfaCd0fZusL8h5avKTkdTjUu2aHhFJhZoVBGVLhoDtUaqZGWIZGcBJOoVf2JkGUOjDRQ==",
       "dev": true,
       "requires": {
         "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.34",
-        "websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
+        "web3-core-helpers": "1.0.0-beta.35",
+        "websocket": "https://registry.npmjs.org/websocket/-/websocket-1.0.26.tgz"
       },
       "dependencies": {
         "underscore": {
@@ -10711,21 +10718,21 @@
       }
     },
     "web3-shh": {
-      "version": "1.0.0-beta.34",
-      "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.0.0-beta.34.tgz",
-      "integrity": "sha1-l1Bh1x6uxCzO5Xb3vY9w8DhEr+A=",
+      "version": "1.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.0.0-beta.35.tgz",
+      "integrity": "sha512-8qSonk/x0xabERS9Sr6AIADN/Ty+5KwARkkGIfSYHKqFpdMDz+76F7cUCxtoCZoS8K04xgZlDKYe0TJXLYA0Fw==",
       "dev": true,
       "requires": {
-        "web3-core": "1.0.0-beta.34",
-        "web3-core-method": "1.0.0-beta.34",
-        "web3-core-subscriptions": "1.0.0-beta.34",
-        "web3-net": "1.0.0-beta.34"
+        "web3-core": "1.0.0-beta.35",
+        "web3-core-method": "1.0.0-beta.35",
+        "web3-core-subscriptions": "1.0.0-beta.35",
+        "web3-net": "1.0.0-beta.35"
       }
     },
     "web3-utils": {
-      "version": "1.0.0-beta.34",
-      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.34.tgz",
-      "integrity": "sha1-lBH8OarvOcpOBhafdiKX2f8CCXA=",
+      "version": "1.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.35.tgz",
+      "integrity": "sha512-Dq6f0SOKj3BDFRgOPnE6ALbzBDCKVIW8mKWVf7tGVhTDHf+wQaWwQSC3aArFSqdExB75BPBPyDpuMTNszhljpA==",
       "dev": true,
       "requires": {
         "bn.js": "4.11.6",
@@ -10931,8 +10938,9 @@
       }
     },
     "websocket": {
-      "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
-      "from": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible",
+      "version": "1.0.26",
+      "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.26.tgz",
+      "integrity": "sha512-fjcrYDPIQxpTnqFQ9JjxUQcdvR89MFAOjPBlF+vjOt49w/XW4fJknUoMz/mDIn2eK1AdslVojcaOxOqyZZV8rw==",
       "dev": true,
       "requires": {
         "debug": "^2.2.0",
@@ -11080,6 +11088,15 @@
       "integrity": "sha1-f4dliEdxbbUCYyOBL4GMras4el8=",
       "dev": true
     },
+    "xhr2-cookies": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/xhr2-cookies/-/xhr2-cookies-1.1.0.tgz",
+      "integrity": "sha1-fXdEnQmZGX8VXLc7I99yUF7YnUg=",
+      "dev": true,
+      "requires": {
+        "cookiejar": "^2.1.1"
+      }
+    },
     "xml": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
@@ -11146,9 +11163,9 @@
       }
     },
     "yauzl": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.9.2.tgz",
-      "integrity": "sha1-T7G8euH8L1cDe1SvasyP4QMcW3c=",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
       "dev": true,
       "requires": {
         "buffer-crc32": "~0.2.3",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "solidity-coverage": "0.5.5",
     "solium": "1.1.8",
     "truffle": "4.1.13",
-    "web3": "1.0.0-beta.34"
+    "web3": "1.0.0-beta.35",
+    "websocket": "1.0.26"
   }
 }


### PR DESCRIPTION
I'm not sure, but I think the websocket problem was coming from older versions of npm or node that were unable to pull the repo directly from git. Here we try including websocket explicitly in package.json and update web3 to the newest version (5 days old)

This person claims that it's docker's fault, but maybe it's because they are running a different node or npm version on their docker https://ethereum.stackexchange.com/questions/47839/cannot-connect-to-infura-inside-a-docker-container-cannot-find-module-websocke

They are using:
node v8.11.3
npm v5.6.0