### PR TITLE
Use provider when snapshotting

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,16 @@ const order = seeds.orders[1];
 console.log(order.maker);
 ```
 
+#### Snapshotting
+
+When using the docker container, you can reset the evm to the default state
+
+```javascript
+import { reset } from '@dydxprotocol/protocol';
+
+await reset(web3.currentProvider);
+```
+
 ## Docker Container
 
 [Docker container](https://hub.docker.com/r/dydxprotocol/protocol/) with a a deployed version of the protocol running on a ganache-cli node with network_id = 1212

--- a/migrations/3_seeds.js
+++ b/migrations/3_seeds.js
@@ -22,7 +22,6 @@ global.web3 = web3;
 const fs = require('fs');
 const promisify = require("es6-promisify");
 const Margin = artifacts.require('Margin');
-const TestToken = artifacts.require('TestToken');
 const { isDevNetwork } = require('./helpers');
 const { snapshot } = require('../src/lib/snapshots');
 const { doOpenPosition, getPosition } = require('../test/helpers/MarginHelper');
@@ -31,7 +30,6 @@ const {
   createBuyOrderForToken,
   createSellOrderForToken
 } = require('../test/helpers/ERC20PositionHelper');
-const { issueAndSetAllowance } = require('../test/helpers/TokenHelper');
 const mkdirp = require('mkdirp');
 
 const mkdirAsync = promisify(mkdirp);
@@ -51,7 +49,7 @@ async function doMigration(deployer, network, accounts) {
 
     const orders = await createSeedOrders(accounts);
 
-    await snapshot(web3);
+    await snapshot(web3.currentProvider);
 
     seeds.positions = positions;
     seeds.orders = orders;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/protocol",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/protocol",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Ethereum Smart Contracts for the dYdX Margin Trading Protocol",
   "main": "dist/index.js",
   "files": [

--- a/src/lib/snapshots.js
+++ b/src/lib/snapshots.js
@@ -18,9 +18,8 @@
 
 import promisify from "es6-promisify";
 
-export async function reset(web3Instance, id) {
-  // Needed for different versions of web3
-  const func = web3Instance.currentProvider.sendAsync || web3Instance.currentProvider.send;
+export async function reset(provider, id) {
+  const func = provider.sendAsync || provider.send;
 
   await promisify(func)({
     jsonrpc: "2.0",
@@ -29,12 +28,12 @@ export async function reset(web3Instance, id) {
     params: [id || '0x01'],
   });
 
-  return snapshot(web3Instance);
+  return snapshot(provider);
 }
 
-export async function snapshot(web3Instance) {
+export async function snapshot(provider) {
   // Needed for different versions of web3
-  const func = web3Instance.currentProvider.sendAsync || web3Instance.currentProvider.send;
+  const func = provider.sendAsync || provider.send;
 
   const response = await promisify(func)({
     jsonrpc: "2.0",

--- a/test/tests/js/TestReset.js
+++ b/test/tests/js/TestReset.js
@@ -1,0 +1,58 @@
+const { reset, snapshot } = require('../../../src/index');
+const chai = require('chai');
+const expect = chai.expect;
+chai.use(require('chai-bignumber')());
+const BigNumber = require('bignumber.js');
+
+const TokenA = artifacts.require('TokenA');
+
+contract('Margin', accounts => {
+  after(async () => {
+    await reset(web3.currentProvider);
+    // Snapshot a final time to fool truffle into reverting to this in the contract block
+    await snapshot(web3.currentProvider);
+  });
+
+  describe('#reset', () => {
+    it('resets any transactions made', async () => {
+      const account = accounts[5];
+      const amount = new BigNumber(123456);
+      const token = await TokenA.deployed();
+
+      const startingBalance = await token.balanceOf.call(account);
+      await token.issueTo(account, amount);
+      const afterBalance = await token.balanceOf.call(account);
+
+      expect(afterBalance).to.be.bignumber.eq(startingBalance.plus(amount));
+
+      await reset(web3.currentProvider);
+
+      const balanceAfterReset = await token.balanceOf.call(account);
+      expect(balanceAfterReset).to.be.bignumber.eq(startingBalance);
+    });
+
+    it('works multiple times', async () => {
+      const account = accounts[5];
+      const amount = new BigNumber(123456);
+      const token = await TokenA.deployed();
+
+      const startingBalance = await token.balanceOf.call(account);
+      await token.issueTo(account, amount);
+      const afterBalance = await token.balanceOf.call(account);
+
+      expect(afterBalance).to.be.bignumber.eq(startingBalance.plus(amount));
+
+      await reset(web3.currentProvider);
+
+      let balanceAfterReset = await token.balanceOf.call(account);
+      expect(balanceAfterReset).to.be.bignumber.eq(startingBalance);
+
+      await token.issueTo(account, amount);
+
+      await reset(web3.currentProvider);
+
+      balanceAfterReset = await token.balanceOf.call(account);
+      expect(balanceAfterReset).to.be.bignumber.eq(startingBalance);
+    });
+  });
+});

--- a/test/tests/js/TestSeeds.js
+++ b/test/tests/js/TestSeeds.js
@@ -3,19 +3,17 @@ const { getPosition } = require('../../helpers/MarginHelper');
 const chai = require('chai');
 const expect = chai.expect;
 chai.use(require('chai-bignumber')());
-const BigNumber = require('bignumber.js');
 const { ZeroEx } = require('0x.js');
 
 const Margin = artifacts.require('Margin');
-const TokenA = artifacts.require('TokenA');
 const TestToken = artifacts.require('TestToken');
 const ZeroExProxy = artifacts.require('ZeroExProxy');
 
-contract('Margin', accounts => {
+contract('Margin', () => {
   after(async () => {
-    await reset(web3);
+    await reset(web3.currentProvider);
     // Snapshot a final time to fool truffle into reverting to this in the contract block
-    await snapshot(web3);
+    await snapshot(web3.currentProvider);
   });
 
   describe('seeds', () => {
@@ -27,7 +25,7 @@ contract('Margin', accounts => {
       it('seed positions still exist after reset', async () => {
         await checkSeedPositions();
 
-        await reset(web3);
+        await reset(web3.currentProvider);
 
         await checkSeedPositions();
       });
@@ -41,53 +39,10 @@ contract('Margin', accounts => {
       it('seed orders still exist after reset', async () => {
         await checkSeedOrders();
 
-        await reset(web3);
+        await reset(web3.currentProvider);
 
         await checkSeedOrders();
       });
-    });
-  });
-
-  describe('#reset', () => {
-    it('resets any transactions made', async () => {
-      const account = accounts[5];
-      const amount = new BigNumber(123456);
-      const token = await TokenA.deployed();
-
-      const startingBalance = await token.balanceOf.call(account);
-      await token.issueTo(account, amount);
-      const afterBalance = await token.balanceOf.call(account);
-
-      expect(afterBalance).to.be.bignumber.eq(startingBalance.plus(amount));
-
-      await reset(web3);
-
-      const balanceAfterReset = await token.balanceOf.call(account);
-      expect(balanceAfterReset).to.be.bignumber.eq(startingBalance);
-    });
-
-    it('works multiple times', async () => {
-      const account = accounts[5];
-      const amount = new BigNumber(123456);
-      const token = await TokenA.deployed();
-
-      const startingBalance = await token.balanceOf.call(account);
-      await token.issueTo(account, amount);
-      const afterBalance = await token.balanceOf.call(account);
-
-      expect(afterBalance).to.be.bignumber.eq(startingBalance.plus(amount));
-
-      await reset(web3);
-
-      let balanceAfterReset = await token.balanceOf.call(account);
-      expect(balanceAfterReset).to.be.bignumber.eq(startingBalance);
-
-      await token.issueTo(account, amount);
-
-      await reset(web3);
-
-      balanceAfterReset = await token.balanceOf.call(account);
-      expect(balanceAfterReset).to.be.bignumber.eq(startingBalance);
     });
   });
 });


### PR DESCRIPTION
Callers should pass in the provider rather than a web3 instance when using snapshotting features. This is useful in cases the caller doesn't have a web3 instance, or is using a different version of web3

Also refactor the js tests