### PR TITLE
fix publish script

### DIFF
--- a/scripts/publish_if_not_exists.sh
+++ b/scripts/publish_if_not_exists.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
-set -e
 
 VERSION=$(cat package.json | jq -r '.version')
 NAME=@dydxprotocol/protocol
@@ -7,6 +6,8 @@ NAME=@dydxprotocol/protocol
 test -z "$(npm info $NAME@$VERSION)"
 if [ $? -eq 0 ]
 then
+    set -e
+
     mkdir -p ~/.ssh
     touch ~/.ssh/known_hosts
     ssh-keyscan -H github.com >> ~/.ssh/known_hosts


### PR DESCRIPTION
The npm publish script was failing anytime it did not need to publish a new version. This was because `set -e` was set on the script and `test -z "$(npm info $NAME@$VERSION)"` would give a nonzero exit code (by design) which would then exit the script with an error code