### PR TITLE
Fix reset / snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,17 +72,17 @@ console.log(order.maker);
 
 #### Snapshotting
 
-When using the docker container, you can reset the evm to the default state
+When using the docker container, you can reset the evm to the default state. This can be useful when running automated test suites
 
 ```javascript
-import { reset } from '@dydxprotocol/protocol';
+import { resetEVM } from '@dydxprotocol/protocol';
 
-await reset(web3.currentProvider);
+await resetEVM(web3.currentProvider);
 ```
 
 ## Docker Container
 
-[Docker container](https://hub.docker.com/r/dydxprotocol/protocol/) with a a deployed version of the protocol running on a ganache-cli node with network_id = 1212
+[Docker container](https://hub.docker.com/r/dydxprotocol/protocol/) with a a deployed version of the protocol running on a ganache-cli node with network_id = 1212. Docker container versions correspond to npm versions of this package, so use the same version for both
 
 ```
 docker pull dydxprotocol/protocol

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/protocol",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2442,12 +2442,14 @@
     "es6-promise": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
-      "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ=="
+      "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ==",
+      "dev": true
     },
     "es6-promisify": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+      "dev": true,
       "requires": {
         "es6-promise": "^4.0.3"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/protocol",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "Ethereum Smart Contracts for the dYdX Margin Trading Protocol",
   "main": "dist/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
   "dependencies": {
     "babel-runtime": "^6.26.0",
     "bignumber.js": "^4.1.0",
-    "es6-promisify": "^5.0.0",
     "zeppelin-solidity": "1.12.0"
   },
   "devDependencies": {
@@ -69,6 +68,7 @@
     "chai": "^4.1.2",
     "chai-bignumber": "^2.0.2",
     "coveralls": "^3.0.2",
+    "es6-promisify": "^5.0.0",
     "eslint": "^4.19.1",
     "ethereumjs-util": "^5.2.0",
     "ganache-cli": "^6.1.8",

--- a/src/lib/snapshots.js
+++ b/src/lib/snapshots.js
@@ -42,32 +42,21 @@ export async function snapshot(provider) {
 }
 
 async function sendAsync(provider, args) {
+  // Needed for different versions of web3
+  const func = provider.sendAsync || provider.send;
   let response;
 
-  // Needed for different versions of web3
-  if (provider.sendAsync) {
-    response = await new Promise((resolve, reject) => provider.sendAsync(
-      args,
-      (err, result) => {
-        if (err) {
-          reject(err);
-        } else {
-          resolve(result);
-        }
+  response = await new Promise((resolve, reject) => func.call(
+    provider,
+    args,
+    (err, result) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(result);
       }
-    ));
-  } else {
-    response = await new Promise((resolve, reject) => provider.send(
-      args,
-      (err, result) => {
-        if (err) {
-          reject(err);
-        } else {
-          resolve(result);
-        }
-      }
-    ));
-  }
+    }
+  ));
 
   return response;
 }

--- a/src/lib/snapshots.js
+++ b/src/lib/snapshots.js
@@ -16,12 +16,30 @@
 
 */
 
+/**
+ * Attempts to reset the EVM to its initial state. Useful for testing suites
+ *
+ * @param {Provider} provider a valid web3 provider
+ * @returns {null} null
+ */
+export async function resetEVM(provider) {
+  const id = await snapshot(provider);
+
+  if (id !== '0x1') {
+    await reset(provider, '0x1');
+  }
+}
+
 export async function reset(provider, id) {
+  if (!id) {
+    throw new Error('id must be set');
+  }
+
   const args = {
     jsonrpc: "2.0",
     method: "evm_revert",
     id: 12345,
-    params: [id || '0x01'],
+    params: [id],
   };
 
   await sendAsync(provider, args);


### PR DESCRIPTION
When the package was being used `reset` and `snapshot` were failing for two reasons:

It failed whenever
```javascrip
const func = provider.sendAsync || provider.send;
func(args)
``` 
was used on a web3 provider object

It also failed whenever `es6-promisify` was used

It would fail with:

```
TypeError: this.prepareRequest is not a function

 at Object.<anonymous>.HttpProvider.sendAsync (node_modules/web3/lib/web3/httpprovider.js:115:22)
      at func (../protocol/src/lib/snapshots.js:46:59)
      at Object._callee2$ (../protocol/src/lib/snapshots.js:46:26)
      at tryCatch (../protocol/node_modules/regenerator-runtime/runtime.js:62:40)
      at Generator.invoke [as _invoke] (../protocol/node_modules/regenerator-runtime/runtime.js:296:22)
      at Generator.prototype.(anonymous function) [as next] (../protocol/node_modules/regenerator-runtime/runtime.js:114:21)
      at step (../protocol/node_modules/babel-runtime/helpers/asyncToGenerator.js:17:30)
      at ../protocol/node_modules/babel-runtime/helpers/asyncToGenerator.js:35:14
      at new F (../protocol/node_modules/core-js/library/modules/_export.js:36:28)
      at Object.<anonymous> (../protocol/node_modules/babel-runtime/helpers/asyncToGenerator.js:14:12)
      at Object.snapshot (../protocol/dist/lib/snapshots.js:110:18)
```