### PR TITLE
remove NoOwner

### DIFF
--- a/contracts/margin/Margin.sol
+++ b/contracts/margin/Margin.sol
@@ -21,7 +21,6 @@ pragma experimental "v0.5.0";
 
 import { ReentrancyGuard } from "openzeppelin-solidity/contracts/ReentrancyGuard.sol";
 import { SafeMath } from "openzeppelin-solidity/contracts/math/SafeMath.sol";
-import { NoOwner } from "openzeppelin-solidity/contracts/ownership/NoOwner.sol";
 import { Vault } from "./Vault.sol";
 import { ClosePositionImpl } from "./impl/ClosePositionImpl.sol";
 import { CloseWithoutCounterpartyImpl } from "./impl/CloseWithoutCounterpartyImpl.sol";
@@ -47,7 +46,6 @@ import { TransferImpl } from "./impl/TransferImpl.sol";
  * This contract is used to facilitate margin trading as per the dYdX protocol
  */
 contract Margin is
-    NoOwner,
     ReentrancyGuard,
     MarginStorage,
     MarginEvents,

--- a/contracts/margin/TokenProxy.sol
+++ b/contracts/margin/TokenProxy.sol
@@ -21,7 +21,6 @@ pragma experimental "v0.5.0";
 
 import { Math } from "openzeppelin-solidity/contracts/math/Math.sol";
 import { SafeMath } from "openzeppelin-solidity/contracts/math/SafeMath.sol";
-import { NoOwner } from "openzeppelin-solidity/contracts/ownership/NoOwner.sol";
 import { StaticAccessControlled } from "../lib/StaticAccessControlled.sol";
 import { TokenInteract } from "../lib/TokenInteract.sol";
 
@@ -32,7 +31,7 @@ import { TokenInteract } from "../lib/TokenInteract.sol";
  *
  * Used to transfer tokens between addresses which have set allowance on this contract.
  */
-contract TokenProxy is StaticAccessControlled, NoOwner {
+contract TokenProxy is StaticAccessControlled {
     using SafeMath for uint256;
 
     // ============ Constructor ============

--- a/contracts/margin/Vault.sol
+++ b/contracts/margin/Vault.sol
@@ -20,7 +20,6 @@ pragma solidity 0.4.24;
 pragma experimental "v0.5.0";
 
 import { SafeMath } from "openzeppelin-solidity/contracts/math/SafeMath.sol";
-import { Ownable } from "openzeppelin-solidity/contracts/ownership/Ownable.sol";
 import { TokenProxy } from "./TokenProxy.sol";
 import { StaticAccessControlled } from "../lib/StaticAccessControlled.sol";
 import { TokenInteract } from "../lib/TokenInteract.sol";
@@ -35,9 +34,7 @@ import { TokenInteract } from "../lib/TokenInteract.sol";
  * Vault only supports ERC20 tokens, and will not accept any tokens that require
  * a tokenFallback or equivalent function (See ERC223, ERC777, etc.)
  */
-contract Vault is
-    Ownable,
-    StaticAccessControlled
+contract Vault is StaticAccessControlled
 {
     using SafeMath for uint256;
 

--- a/contracts/margin/external/BucketLender/BucketLenderFactory.sol
+++ b/contracts/margin/external/BucketLender/BucketLenderFactory.sol
@@ -19,7 +19,6 @@
 pragma solidity 0.4.24;
 pragma experimental "v0.5.0";
 
-import { Ownable } from "openzeppelin-solidity/contracts/ownership/Ownable.sol";
 import { BucketLender } from "./BucketLender.sol";
 
 
@@ -99,7 +98,7 @@ contract BucketLenderFactory {
             withdrawers
         );
 
-        Ownable(newBucketLender).transferOwnership(owner);
+        BucketLender(newBucketLender).transferOwnership(owner);
 
         emit BucketLenderCreated(
             msg.sender,

--- a/contracts/margin/external/ERC20/ERC20PositionFactory.sol
+++ b/contracts/margin/external/ERC20/ERC20PositionFactory.sol
@@ -20,7 +20,6 @@ pragma solidity 0.4.24;
 pragma experimental "v0.5.0";
 
 import { ReentrancyGuard } from "openzeppelin-solidity/contracts/ReentrancyGuard.sol";
-import { NoOwner } from "openzeppelin-solidity/contracts/ownership/NoOwner.sol";
 import { OnlyMargin } from "../../interfaces/OnlyMargin.sol";
 import { PositionOwner } from "../../interfaces/owner/PositionOwner.sol";
 
@@ -33,7 +32,6 @@ import { PositionOwner } from "../../interfaces/owner/PositionOwner.sol";
  */
 contract ERC20PositionFactory is
     ReentrancyGuard,
-    NoOwner,
     OnlyMargin,
     PositionOwner
 {

--- a/contracts/margin/external/SharedLoanFactory.sol
+++ b/contracts/margin/external/SharedLoanFactory.sol
@@ -20,7 +20,6 @@ pragma solidity 0.4.24;
 pragma experimental "v0.5.0";
 
 import { ReentrancyGuard } from "openzeppelin-solidity/contracts/ReentrancyGuard.sol";
-import { NoOwner } from "openzeppelin-solidity/contracts/ownership/NoOwner.sol";
 import { SharedLoan } from "./SharedLoan.sol";
 import { OnlyMargin } from "../interfaces/OnlyMargin.sol";
 import { LoanOwner } from "../interfaces/lender/LoanOwner.sol";
@@ -37,7 +36,6 @@ import { LoanOwner } from "../interfaces/lender/LoanOwner.sol";
  */
 contract SharedLoanFactory is
     ReentrancyGuard,
-    NoOwner,
     OnlyMargin,
     LoanOwner
 {


### PR DESCRIPTION
Removed from OpenZeppelin and is unnecessary.
`contract NoOwner is HasNoEther, HasNoTokens, HasNoContracts { }`

Secondarily: removed `Ownable` from some contracts that already have it though secondary inheritance
