### PR TITLE
add optimizedReentrancyGuard

### DIFF
--- a/contracts/external/0x/v2/protocol/Exchange/ZeroExExchangeV2.sol
+++ b/contracts/external/0x/v2/protocol/Exchange/ZeroExExchangeV2.sol
@@ -21,7 +21,7 @@ pragma experimental ABIEncoderV2;
 
 import { Math } from "openzeppelin-solidity/contracts/math/Math.sol";
 import { Ownable } from "openzeppelin-solidity/contracts/ownership/Ownable.sol";
-import { ReentrancyGuard } from "openzeppelin-solidity/contracts/ReentrancyGuard.sol";
+import { ReentrancyGuard } from "../../../../../lib/ReentrancyGuard.sol";
 import "./libs/LibConstants.sol";
 import "./libs/LibMath.sol";
 import "./libs/LibOrder.sol";

--- a/contracts/lib/ReentrancyGuard.sol
+++ b/contracts/lib/ReentrancyGuard.sol
@@ -1,0 +1,47 @@
+/*
+
+    Copyright 2018 dYdX Trading Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+*/
+
+pragma solidity 0.4.24;
+
+
+/**
+ * @title ReentrancyGuard
+ * @author dYdX
+ *
+ * Optimized version of the well-known ReentrancyGuard contract
+ */
+contract ReentrancyGuard {
+
+    uint256 private _guardCounter = 1;
+
+    modifier nonReentrant() {
+        // SLOAD
+        uint256 localCounter = _guardCounter + 1;
+
+        // SSTORE
+        _guardCounter = localCounter;
+
+        _;
+
+        // SLOAD
+        require(
+            _guardCounter == localCounter,
+            "Reentrancy check failure"
+        );
+    }
+}

--- a/contracts/lib/ReentrancyGuard.sol
+++ b/contracts/lib/ReentrancyGuard.sol
@@ -26,19 +26,12 @@ pragma solidity 0.4.24;
  * Optimized version of the well-known ReentrancyGuard contract
  */
 contract ReentrancyGuard {
-
     uint256 private _guardCounter = 1;
 
     modifier nonReentrant() {
-        // SLOAD
         uint256 localCounter = _guardCounter + 1;
-
-        // SSTORE
         _guardCounter = localCounter;
-
         _;
-
-        // SLOAD
         require(
             _guardCounter == localCounter,
             "Reentrancy check failure"

--- a/contracts/margin/Margin.sol
+++ b/contracts/margin/Margin.sol
@@ -19,9 +19,9 @@
 pragma solidity 0.4.24;
 pragma experimental "v0.5.0";
 
-import { ReentrancyGuard } from "openzeppelin-solidity/contracts/ReentrancyGuard.sol";
 import { SafeMath } from "openzeppelin-solidity/contracts/math/SafeMath.sol";
 import { Vault } from "./Vault.sol";
+import { ReentrancyGuard } from "../lib/ReentrancyGuard.sol";
 import { ClosePositionImpl } from "./impl/ClosePositionImpl.sol";
 import { CloseWithoutCounterpartyImpl } from "./impl/CloseWithoutCounterpartyImpl.sol";
 import { DepositCollateralImpl } from "./impl/DepositCollateralImpl.sol";

--- a/contracts/margin/external/BucketLender/BucketLender.sol
+++ b/contracts/margin/external/BucketLender/BucketLender.sol
@@ -762,7 +762,7 @@ contract BucketLender is
             lockedBucket = criticalBucket;
         }
 
-        uint256[2] memory results; // [0] = owedToken, [1] = heldToken
+        uint256[2] memory results; // [0] = totalOwedToken, [1] = totalHeldToken
 
         uint256 maxHeldToken = 0;
         if (wasForceClosed) {

--- a/contracts/margin/external/BucketLender/BucketLender.sol
+++ b/contracts/margin/external/BucketLender/BucketLender.sol
@@ -19,12 +19,12 @@
 pragma solidity 0.4.24;
 pragma experimental "v0.5.0";
 
-import { ReentrancyGuard } from "openzeppelin-solidity/contracts/ReentrancyGuard.sol";
 import { Math } from "openzeppelin-solidity/contracts/math/Math.sol";
 import { SafeMath } from "openzeppelin-solidity/contracts/math/SafeMath.sol";
 import { Ownable } from "openzeppelin-solidity/contracts/ownership/Ownable.sol";
 import { Margin } from "../../Margin.sol";
 import { MathHelpers } from "../../../lib/MathHelpers.sol";
+import { ReentrancyGuard } from "../../../lib/ReentrancyGuard.sol";
 import { TokenInteract } from "../../../lib/TokenInteract.sol";
 import { MarginCommon } from "../../impl/MarginCommon.sol";
 import { LoanOfferingVerifier } from "../../interfaces/LoanOfferingVerifier.sol";
@@ -762,8 +762,7 @@ contract BucketLender is
             lockedBucket = criticalBucket;
         }
 
-        uint256 totalOwedToken = 0;
-        uint256 totalHeldToken = 0;
+        uint256[2] memory results; // [0] = owedToken, [1] = heldToken
 
         uint256 maxHeldToken = 0;
         if (wasForceClosed) {
@@ -785,15 +784,15 @@ contract BucketLender is
                 maxHeldToken
             );
 
-            totalOwedToken = totalOwedToken.add(owedTokenForBucket);
-            totalHeldToken = totalHeldToken.add(heldTokenForBucket);
+            results[0] = results[0].add(owedTokenForBucket);
+            results[1] = results[1].add(heldTokenForBucket);
         }
 
         // Transfer share of owedToken
-        OWED_TOKEN.transfer(msg.sender, totalOwedToken);
-        HELD_TOKEN.transfer(msg.sender, totalHeldToken);
+        OWED_TOKEN.transfer(msg.sender, results[0]);
+        HELD_TOKEN.transfer(msg.sender, results[1]);
 
-        return (totalOwedToken, totalHeldToken);
+        return (results[0], results[1]);
     }
 
     /**

--- a/contracts/margin/external/ERC20/ERC20Position.sol
+++ b/contracts/margin/external/ERC20/ERC20Position.sol
@@ -19,12 +19,12 @@
 pragma solidity 0.4.24;
 pragma experimental "v0.5.0";
 
-import { ReentrancyGuard } from "openzeppelin-solidity/contracts/ReentrancyGuard.sol";
 import { Math } from "openzeppelin-solidity/contracts/math/Math.sol";
 import { SafeMath } from "openzeppelin-solidity/contracts/math/SafeMath.sol";
 import { StandardToken } from "openzeppelin-solidity/contracts/token/ERC20/StandardToken.sol";
 import { Margin } from "../../Margin.sol";
 import { MathHelpers } from "../../../lib/MathHelpers.sol";
+import { ReentrancyGuard } from "../../../lib/ReentrancyGuard.sol";
 import { TokenInteract } from "../../../lib/TokenInteract.sol";
 import { MarginCommon } from "../../impl/MarginCommon.sol";
 import { OnlyMargin } from "../../interfaces/OnlyMargin.sol";

--- a/contracts/margin/external/ERC20/ERC20PositionFactory.sol
+++ b/contracts/margin/external/ERC20/ERC20PositionFactory.sol
@@ -19,7 +19,7 @@
 pragma solidity 0.4.24;
 pragma experimental "v0.5.0";
 
-import { ReentrancyGuard } from "openzeppelin-solidity/contracts/ReentrancyGuard.sol";
+import { ReentrancyGuard } from "../../../lib/ReentrancyGuard.sol";
 import { OnlyMargin } from "../../interfaces/OnlyMargin.sol";
 import { PositionOwner } from "../../interfaces/owner/PositionOwner.sol";
 

--- a/contracts/margin/external/ERC20/ERC20PositionWithdrawer.sol
+++ b/contracts/margin/external/ERC20/ERC20PositionWithdrawer.sol
@@ -20,8 +20,8 @@ pragma solidity 0.4.24;
 pragma experimental "v0.5.0";
 
 import { WETH9 } from "canonical-weth/contracts/WETH9.sol";
-import { ReentrancyGuard } from "openzeppelin-solidity/contracts/ReentrancyGuard.sol";
 import { ERC20Position } from "./ERC20Position.sol";
+import { ReentrancyGuard } from "../../../lib/ReentrancyGuard.sol";
 import { TokenInteract } from "../../../lib/TokenInteract.sol";
 import { ExchangeWrapper } from "../../interfaces/ExchangeWrapper.sol";
 

--- a/contracts/margin/external/ERC721/ERC721MarginLoan.sol
+++ b/contracts/margin/external/ERC721/ERC721MarginLoan.sol
@@ -19,10 +19,10 @@
 pragma solidity 0.4.24;
 pragma experimental "v0.5.0";
 
-import { ReentrancyGuard } from "openzeppelin-solidity/contracts/ReentrancyGuard.sol";
 import { SafeMath } from "openzeppelin-solidity/contracts/math/SafeMath.sol";
 import { ERC721Token } from "openzeppelin-solidity/contracts/token/ERC721/ERC721Token.sol";
 import { Margin } from "../../Margin.sol";
+import { ReentrancyGuard } from "../../../lib/ReentrancyGuard.sol";
 import { TokenInteract } from "../../../lib/TokenInteract.sol";
 import { OnlyMargin } from "../../interfaces/OnlyMargin.sol";
 /* solium-disable-next-line max-len*/

--- a/contracts/margin/external/ERC721/ERC721MarginPosition.sol
+++ b/contracts/margin/external/ERC721/ERC721MarginPosition.sol
@@ -19,10 +19,10 @@
 pragma solidity 0.4.24;
 pragma experimental "v0.5.0";
 
-import { ReentrancyGuard } from "openzeppelin-solidity/contracts/ReentrancyGuard.sol";
 import { SafeMath } from "openzeppelin-solidity/contracts/math/SafeMath.sol";
 import { ERC721Token } from "openzeppelin-solidity/contracts/token/ERC721/ERC721Token.sol";
 import { Margin } from "../../Margin.sol";
+import { ReentrancyGuard } from "../../../lib/ReentrancyGuard.sol";
 import { OnlyMargin } from "../../interfaces/OnlyMargin.sol";
 import { ClosePositionDelegator } from "../../interfaces/owner/ClosePositionDelegator.sol";
 import { DepositCollateralDelegator } from "../../interfaces/owner/DepositCollateralDelegator.sol";

--- a/contracts/margin/external/PayableMarginMinter.sol
+++ b/contracts/margin/external/PayableMarginMinter.sol
@@ -20,9 +20,9 @@ pragma solidity 0.4.24;
 pragma experimental "v0.5.0";
 
 import { WETH9 } from "canonical-weth/contracts/WETH9.sol";
-import { ReentrancyGuard } from "openzeppelin-solidity/contracts/ReentrancyGuard.sol";
 import { Margin } from "../Margin.sol";
 import { MathHelpers } from "../../lib/MathHelpers.sol";
+import { ReentrancyGuard } from "../../lib/ReentrancyGuard.sol";
 import { TokenInteract } from "../../lib/TokenInteract.sol";
 
 

--- a/contracts/margin/external/SharedLoan.sol
+++ b/contracts/margin/external/SharedLoan.sol
@@ -19,10 +19,10 @@
 pragma solidity 0.4.24;
 pragma experimental "v0.5.0";
 
-import { ReentrancyGuard } from "openzeppelin-solidity/contracts/ReentrancyGuard.sol";
 import { SafeMath } from "openzeppelin-solidity/contracts/math/SafeMath.sol";
 import { Margin } from "../Margin.sol";
 import { MathHelpers } from "../../lib/MathHelpers.sol";
+import { ReentrancyGuard } from "../../lib/ReentrancyGuard.sol";
 import { TokenInteract } from "../../lib/TokenInteract.sol";
 import { MarginCommon } from "../impl/MarginCommon.sol";
 import { OnlyMargin } from "../interfaces/OnlyMargin.sol";

--- a/contracts/margin/external/SharedLoanFactory.sol
+++ b/contracts/margin/external/SharedLoanFactory.sol
@@ -19,8 +19,8 @@
 pragma solidity 0.4.24;
 pragma experimental "v0.5.0";
 
-import { ReentrancyGuard } from "openzeppelin-solidity/contracts/ReentrancyGuard.sol";
 import { SharedLoan } from "./SharedLoan.sol";
+import { ReentrancyGuard } from "../../lib/ReentrancyGuard.sol";
 import { OnlyMargin } from "../interfaces/OnlyMargin.sol";
 import { LoanOwner } from "../interfaces/lender/LoanOwner.sol";
 

--- a/contracts/testing/TestNonReentrant.sol
+++ b/contracts/testing/TestNonReentrant.sol
@@ -1,0 +1,39 @@
+/*
+
+    Copyright 2018 dYdX Trading Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+*/
+
+pragma solidity 0.4.24;
+pragma experimental "v0.5.0";
+
+import { ReentrancyGuard } from "../lib/ReentrancyGuard.sol";
+import { TestReenterer } from "./TestReenterer.sol";
+
+
+contract TestNonReentrant is ReentrancyGuard {
+    function function1(address reenterer)
+        external
+        nonReentrant
+    {
+        TestReenterer(reenterer).reenterMe();
+    }
+
+    function function2()
+        external
+        nonReentrant
+    {
+    }
+}

--- a/contracts/testing/TestReenterer.sol
+++ b/contracts/testing/TestReenterer.sol
@@ -1,0 +1,31 @@
+/*
+
+    Copyright 2018 dYdX Trading Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+*/
+
+pragma solidity 0.4.24;
+pragma experimental "v0.5.0";
+
+import { TestNonReentrant } from "./TestNonReentrant.sol";
+
+
+contract TestReenterer {
+    function reenterMe()
+        external
+    {
+        TestNonReentrant(msg.sender).function2();
+    }
+}

--- a/test/tests/lib/TestNonReentrant.js
+++ b/test/tests/lib/TestNonReentrant.js
@@ -1,0 +1,21 @@
+const TestNonReentrant = artifacts.require("TestNonReentrant");
+const TestReenterer = artifacts.require("TestReenterer");
+const { expectThrow } = require('../../helpers/ExpectHelper');
+
+contract('TestNonReentrant', function() {
+  describe('#nonReentrant', () => {
+    it('prevents reentrancy', async() => {
+      const [
+        contract,
+        reenterer
+      ] = await Promise.all([
+        TestNonReentrant.new(),
+        TestReenterer.new()
+      ]);
+
+      await expectThrow(
+        contract.function1(reenterer.address)
+      );
+    });
+  });
+});


### PR DESCRIPTION
Add this if we release before Open-Zeppelin updates to v1.12

Unfortunately, this change adds a local variable to the modifier, which contributes to the 16-variable stack limit for any function that uses this modifier