### PR TITLE
change symbol for ERC20 Margin Tokens

### DIFF
--- a/contracts/lib/StringHelpers.sol
+++ b/contracts/lib/StringHelpers.sol
@@ -58,7 +58,7 @@ library StringHelpers {
     }
 
     /**
-     * Translates a bytes32 into an ascii hexadecimal representation of those bytes "0x..."
+     * Translates a bytes32 to an ascii hexadecimal representation starting with "0x"
      *
      * @param  input  The bytes to convert to hexadecimal
      * @return        A representation of the bytes in ascii hexadecimal
@@ -71,7 +71,7 @@ library StringHelpers {
         returns (bytes)
     {
         uint256 number = uint256(input);
-        bytes memory numberAsString = new bytes(66);
+        bytes memory numberAsString = new bytes(66); // "0x" and then 2 chars per byte
         numberAsString[0] = byte(48);  // '0'
         numberAsString[1] = byte(120); // 'x'
 

--- a/contracts/lib/StringHelpers.sol
+++ b/contracts/lib/StringHelpers.sol
@@ -58,7 +58,7 @@ library StringHelpers {
     }
 
     /**
-     * Translates a bytes32 into an ascii hexadecimal representation of those bytes
+     * Translates a bytes32 into an ascii hexadecimal representation of those bytes "0x..."
      *
      * @param  input  The bytes to convert to hexadecimal
      * @return        A representation of the bytes in ascii hexadecimal
@@ -70,8 +70,10 @@ library StringHelpers {
         pure
         returns (bytes)
     {
-        bytes memory numberAsString = new bytes(64);
         uint256 number = uint256(input);
+        bytes memory numberAsString = new bytes(66);
+        numberAsString[0] = byte(48);  // '0'
+        numberAsString[1] = byte(120); // 'x'
 
         for (uint256 n = 0; n < 32; n++) {
             uint256 nthByte = number / uint256(uint256(2) ** uint256(248 - 8 * n));
@@ -83,8 +85,8 @@ library StringHelpers {
             // 87 is ascii for '0', 48 is ascii for 'a'
             hex1 += (hex1 > 9) ? 87 : 48; // shift into proper ascii value
             hex2 += (hex2 > 9) ? 87 : 48; // shift into proper ascii value
-            numberAsString[2 * n] = byte(hex1);
-            numberAsString[2 * n + 1] = byte(hex2);
+            numberAsString[2 * n + 2] = byte(hex1);
+            numberAsString[2 * n + 3] = byte(hex2);
         }
         return numberAsString;
     }

--- a/contracts/margin/external/ERC20/ERC20Long.sol
+++ b/contracts/margin/external/ERC20/ERC20Long.sol
@@ -23,6 +23,7 @@ import { DetailedERC20 } from "openzeppelin-solidity/contracts/token/ERC20/Detai
 import { ERC20Position } from "./ERC20Position.sol";
 import { Margin } from "../../Margin.sol";
 import { MathHelpers } from "../../../lib/MathHelpers.sol";
+import { StringHelpers } from "../../../lib/StringHelpers.sol";
 
 
 /**
@@ -50,8 +51,7 @@ contract ERC20Long is ERC20Position {
             margin,
             initialTokenHolder,
             trustedRecipients,
-            trustedWithdrawers,
-            "d/LL"
+            trustedWithdrawers
         )
     {}
 
@@ -62,8 +62,39 @@ contract ERC20Long is ERC20Position {
         view
         returns (uint8)
     {
-        return
-            DetailedERC20(heldToken).decimals();
+        return DetailedERC20(heldToken).decimals();
+    }
+
+    function symbol()
+        external
+        view
+        returns (string)
+    {
+        if (state == State.UNINITIALIZED) {
+            return "l[UNINITIALIZED]";
+        }
+        return string(
+            StringHelpers.strcat(
+                "l",
+                bytes(DetailedERC20(heldToken).symbol())
+            )
+        );
+    }
+
+    function name()
+        external
+        view
+        returns (string)
+    {
+        if (state == State.UNINITIALIZED) {
+            return "dYdX Leveraged Long Token [UNINITIALIZED]";
+        }
+        return string(
+            StringHelpers.strcat(
+                "dYdX Leveraged Long Token ",
+                StringHelpers.bytes32ToHex(POSITION_ID)
+            )
+        );
     }
 
     // ============ Private Functions ============
@@ -125,13 +156,5 @@ contract ERC20Long is ERC20Position {
         );
 
         return (allowedTokenAmount, allowedCloseAmount);
-    }
-
-    function getNameIntro()
-        private
-        pure
-        returns (bytes)
-    {
-        return "dYdX Leveraged Long Token";
     }
 }

--- a/contracts/margin/external/ERC20/ERC20Position.sol
+++ b/contracts/margin/external/ERC20/ERC20Position.sol
@@ -25,7 +25,6 @@ import { SafeMath } from "openzeppelin-solidity/contracts/math/SafeMath.sol";
 import { StandardToken } from "openzeppelin-solidity/contracts/token/ERC20/StandardToken.sol";
 import { Margin } from "../../Margin.sol";
 import { MathHelpers } from "../../../lib/MathHelpers.sol";
-import { StringHelpers } from "../../../lib/StringHelpers.sol";
 import { TokenInteract } from "../../../lib/TokenInteract.sol";
 import { MarginCommon } from "../../impl/MarginCommon.sol";
 import { OnlyMargin } from "../../interfaces/OnlyMargin.sol";
@@ -119,9 +118,6 @@ contract ERC20Position is
     // Current State of this contract. See State enum
     State public state;
 
-    // Symbol to be ERC20 compliant with frontends
-    string public symbol;
-
     // Address of the position's heldToken. Cached for convenience and lower-cost withdrawals
     address public heldToken;
 
@@ -153,8 +149,7 @@ contract ERC20Position is
         address margin,
         address initialTokenHolder,
         address[] trustedRecipients,
-        address[] trustedWithdrawers,
-        string _symbol
+        address[] trustedWithdrawers
     )
         public
         OnlyMargin(margin)
@@ -162,7 +157,6 @@ contract ERC20Position is
         POSITION_ID = positionId;
         state = State.UNINITIALIZED;
         INITIAL_TOKEN_HOLDER = initialTokenHolder;
-        symbol = _symbol;
         closedUsingTrustedRecipient = false;
 
         uint256 i;
@@ -369,31 +363,14 @@ contract ERC20Position is
         returns (uint8);
 
     /**
-     * ERC20 name function. Returns a name based off positionId.
+     * ERC20 symbol function.
      *
-     * NOTE: This is not a gas-efficient function and is not intended to be used on-chain
-     *
-     * @return  The name of the token which includes the hexadecimal positionId
+     * @return  The symbol of the Margin Token
      */
-    function name()
+    function symbol()
         external
         view
-        returns (string)
-    {
-        if (state == State.UNINITIALIZED) {
-            return string(StringHelpers.strcat(getNameIntro(), " [UNINITIALIZED]"));
-        }
-
-        return string(
-            StringHelpers.strcat(
-                StringHelpers.strcat(
-                    getNameIntro(),
-                    " 0x"
-                ),
-                StringHelpers.bytes32ToHex(POSITION_ID)
-            )
-        );
-    }
+        returns (string);
 
     /**
      * Implements PositionCustodian functionality. Called by external contracts to see where to pay
@@ -540,9 +517,4 @@ contract ERC20Position is
             uint256 /* tokenAmount */,
             uint256 /* allowedCloseAmount */
         );
-
-    function getNameIntro()
-        private
-        pure
-        returns (bytes);
 }

--- a/contracts/margin/external/ERC20/ERC20Short.sol
+++ b/contracts/margin/external/ERC20/ERC20Short.sol
@@ -23,6 +23,7 @@ import { Math } from "openzeppelin-solidity/contracts/math/Math.sol";
 import { DetailedERC20 } from "openzeppelin-solidity/contracts/token/ERC20/DetailedERC20.sol";
 import { ERC20Position } from "./ERC20Position.sol";
 import { Margin } from "../../Margin.sol";
+import { StringHelpers } from "../../../lib/StringHelpers.sol";
 
 
 /**
@@ -50,8 +51,7 @@ contract ERC20Short is ERC20Position {
             margin,
             initialTokenHolder,
             trustedRecipients,
-            trustedWithdrawers,
-            "d/S"
+            trustedWithdrawers
         )
     {}
 
@@ -64,6 +64,39 @@ contract ERC20Short is ERC20Position {
     {
         address owedToken = Margin(DYDX_MARGIN).getPositionOwedToken(POSITION_ID);
         return DetailedERC20(owedToken).decimals();
+    }
+
+    function symbol()
+        external
+        view
+        returns (string)
+    {
+        if (state == State.UNINITIALIZED) {
+            return "s[UNINITIALIZED]";
+        }
+        address owedToken = Margin(DYDX_MARGIN).getPositionOwedToken(POSITION_ID);
+        return string(
+            StringHelpers.strcat(
+                "s",
+                bytes(DetailedERC20(owedToken).symbol())
+            )
+        );
+    }
+
+    function name()
+        external
+        view
+        returns (string)
+    {
+        if (state == State.UNINITIALIZED) {
+            return "dYdX Short Token [UNINITIALIZED]";
+        }
+        return string(
+            StringHelpers.strcat(
+                "dYdX Short Token ",
+                StringHelpers.bytes32ToHex(POSITION_ID)
+            )
+        );
     }
 
     // ============ Private Functions ============
@@ -96,13 +129,5 @@ contract ERC20Short is ERC20Position {
         uint256 amount = Math.min256(balance, requestedCloseAmount);
 
         return (amount, amount);
-    }
-
-    function getNameIntro()
-        private
-        pure
-        returns (bytes)
-    {
-        return "dYdX Short Token";
     }
 }

--- a/contracts/testing/TokenA.sol
+++ b/contracts/testing/TokenA.sol
@@ -23,4 +23,14 @@ import { TestToken } from "./TestToken.sol";
 
 
 /* solium-disable-next-line */
-contract TokenA is TestToken {}
+contract TokenA is TestToken {
+    function decimals() public pure returns (uint8) {
+        return 11;
+    }
+    function symbol() public pure returns (string) {
+        return "AAA";
+    }
+    function name() public pure returns (string) {
+        return "Test Token A";
+    }
+}

--- a/contracts/testing/TokenB.sol
+++ b/contracts/testing/TokenB.sol
@@ -23,4 +23,14 @@ import { TestToken } from "./TestToken.sol";
 
 
 /* solium-disable-next-line */
-contract TokenB is TestToken {}
+contract TokenB is TestToken {
+    function decimals() public pure returns (uint8) {
+        return 22;
+    }
+    function symbol() public pure returns (string) {
+        return "BBB";
+    }
+    function name() public pure returns (string) {
+        return "Test Token B";
+    }
+}

--- a/contracts/testing/TokenC.sol
+++ b/contracts/testing/TokenC.sol
@@ -23,4 +23,14 @@ import { TestToken } from "./TestToken.sol";
 
 
 /* solium-disable-next-line */
-contract TokenC is TestToken {}
+contract TokenC is TestToken {
+    function decimals() public pure returns (uint8) {
+        return 33;
+    }
+    function symbol() public pure returns (string) {
+        return "CCC";
+    }
+    function name() public pure returns (string) {
+        return "Test Token C";
+    }
+}

--- a/test/tests/margin/external/erc20/ERC20PositionHelper.js
+++ b/test/tests/margin/external/erc20/ERC20PositionHelper.js
@@ -11,8 +11,6 @@ async function getERC20PositionConstants(erc20Contract) {
     DYDX_MARGIN,
     POSITION_ID,
     state,
-    name,
-    symbol,
     INITIAL_TOKEN_HOLDER,
     heldToken,
     totalSupply
@@ -20,18 +18,15 @@ async function getERC20PositionConstants(erc20Contract) {
     erc20Contract.DYDX_MARGIN.call(),
     erc20Contract.POSITION_ID.call(),
     erc20Contract.state.call(),
-    erc20Contract.name.call(),
-    erc20Contract.symbol.call(),
     erc20Contract.INITIAL_TOKEN_HOLDER.call(),
     erc20Contract.heldToken.call(),
     erc20Contract.totalSupply.call(),
   ]);
+
   return {
     DYDX_MARGIN,
     POSITION_ID,
     state,
-    name,
-    symbol,
     INITIAL_TOKEN_HOLDER,
     heldToken,
     totalSupply

--- a/test/tests/margin/external/erc20/TestERC20Long.js
+++ b/test/tests/margin/external/erc20/TestERC20Long.js
@@ -229,8 +229,6 @@ contract('ERC20Long', accounts => {
         expect(tsc.state).to.be.bignumber.eq(TOKENIZED_POSITION_STATE.UNINITIALIZED);
         expect(tsc.INITIAL_TOKEN_HOLDER).to.eq(INITIAL_TOKEN_HOLDER);
         expect(tsc.heldToken).to.eq(ADDRESSES.ZERO);
-        expect(tsc.symbol).to.eq("d/LL");
-        expect(tsc.name).to.eq("dYdX Leveraged Long Token [UNINITIALIZED]");
         for (let i in position.TRUSTED_RECIPIENTS) {
           const recipient = position.TRUSTED_RECIPIENTS[i];
           const isIn = await position.TOKEN_CONTRACT.TRUSTED_RECIPIENTS.call(recipient);
@@ -925,7 +923,7 @@ contract('ERC20Long', accounts => {
       }
     });
 
-    it('fails  if not initialized', async () => {
+    it('fails if not initialized', async () => {
       await setUpPositions();
       const tokenContract = await ERC20Long.new(
         POSITIONS.FULL.ID,
@@ -952,6 +950,43 @@ contract('ERC20Long', accounts => {
         ]);
         expect(positionId).to.be.bignumber.eq(POSITION.ID);
         expect(tokenName).to.eq("dYdX Leveraged Long Token " + POSITION.ID.toString());
+      }
+    });
+
+    it('succeeds if UNINITIALIZED', async () => {
+      await setUpTokens();
+      for (let type in POSITIONS) {
+        const POSITION = POSITIONS[type];
+        const tokenName = await POSITION.TOKEN_CONTRACT.name.call();
+        expect(tokenName).to.eq("dYdX Leveraged Long Token [UNINITIALIZED]");
+      }
+    });
+  });
+
+  describe('#symbol', () => {
+    it('successfully returns the positionId of the position', async () => {
+      await setUpPositions();
+      await setUpTokens();
+      await transferPositionsToTokens();
+
+      for (let type in POSITIONS) {
+        const POSITION = POSITIONS[type];
+        const [positionId, tokenSymbol, heldTokenSymbol] = await Promise.all([
+          POSITION.TOKEN_CONTRACT.POSITION_ID.call(),
+          POSITION.TOKEN_CONTRACT.symbol.call(),
+          heldToken.symbol.call()
+        ]);
+        expect(positionId).to.be.bignumber.eq(POSITION.ID);
+        expect(tokenSymbol).to.eq("l" + heldTokenSymbol);
+      }
+    });
+
+    it('succeeds if UNINITIALIZED', async () => {
+      await setUpTokens();
+      for (let type in POSITIONS) {
+        const POSITION = POSITIONS[type];
+        const tokenName = await POSITION.TOKEN_CONTRACT.symbol.call();
+        expect(tokenName).to.eq("l[UNINITIALIZED]");
       }
     });
   });

--- a/test/tests/margin/external/erc20/TestERC20Short.js
+++ b/test/tests/margin/external/erc20/TestERC20Short.js
@@ -232,8 +232,6 @@ contract('ERC20Short', accounts => {
         expect(tsc.state).to.be.bignumber.eq(TOKENIZED_POSITION_STATE.UNINITIALIZED);
         expect(tsc.INITIAL_TOKEN_HOLDER).to.eq(INITIAL_TOKEN_HOLDER);
         expect(tsc.heldToken).to.eq(ADDRESSES.ZERO);
-        expect(tsc.symbol).to.eq("d/S");
-        expect(tsc.name).to.eq("dYdX Short Token [UNINITIALIZED]");
         for (let i in position.TRUSTED_RECIPIENTS) {
           const recipient = position.TRUSTED_RECIPIENTS[i];
           const isIn = await position.TOKEN_CONTRACT.TRUSTED_RECIPIENTS.call(recipient);
@@ -954,6 +952,43 @@ contract('ERC20Short', accounts => {
         ]);
         expect(positionId).to.be.bignumber.eq(POSITION.ID);
         expect(tokenName).to.eq("dYdX Short Token " + POSITION.ID.toString());
+      }
+    });
+
+    it('succeeds if UNINITIALIZED', async () => {
+      await setUpTokens();
+      for (let type in POSITIONS) {
+        const POSITION = POSITIONS[type];
+        const tokenName = await POSITION.TOKEN_CONTRACT.name.call();
+        expect(tokenName).to.eq("dYdX Short Token [UNINITIALIZED]");
+      }
+    });
+  });
+
+  describe('#symbol', () => {
+    it('successfully returns the positionId of the position', async () => {
+      await setUpPositions();
+      await setUpTokens();
+      await transferPositionsToTokens();
+
+      for (let type in POSITIONS) {
+        const POSITION = POSITIONS[type];
+        const [positionId, tokenSymbol, owedTokenSymbol] = await Promise.all([
+          POSITION.TOKEN_CONTRACT.POSITION_ID.call(),
+          POSITION.TOKEN_CONTRACT.symbol.call(),
+          owedToken.symbol.call()
+        ]);
+        expect(positionId).to.be.bignumber.eq(POSITION.ID);
+        expect(tokenSymbol).to.eq("s" + owedTokenSymbol);
+      }
+    });
+
+    it('succeeds if UNINITIALIZED', async () => {
+      await setUpTokens();
+      for (let type in POSITIONS) {
+        const POSITION = POSITIONS[type];
+        const tokenName = await POSITION.TOKEN_CONTRACT.symbol.call();
+        expect(tokenName).to.eq("s[UNINITIALIZED]");
       }
     });
   });


### PR DESCRIPTION
fixes #444 

`l[UNINITIALIZED]` , `dYdX Leveraged Long Token [UNINITIALIZED]`
`s[UNINITIALIZED]` , `dYdX Short Token [UNINITIALIZED]`

Initialized Longs:
`lETH`
`dYdX Leveraged Long Token 0x0d1d4e623d10f9fba5db95830f7d3839406c6af20d1d4e623d10f9fba5db9583`

Initialized Shorts
`sETH`
`dYdX Short Token 0x0d1d4e623d10f9fba5db95830f7d3839406c6af20d1d4e623d10f9fba5db9583`