### PR TITLE
make BucketLender getter functions public

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/protocol",
-  "version": "0.2.19",
+  "version": "0.2.20",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/protocol",
-  "version": "0.2.19",
+  "version": "0.2.20",
   "description": "Ethereum Smart Contracts for the dYdX Margin Trading Protocol",
   "main": "dist/index.js",
   "files": [


### PR DESCRIPTION
- changes `getCurrentBucket()` to public
- changes `getBucketOwedAmount()` to public
- removes `getPositionPrincipal()` as a private getter