### PR TITLE
add token naming to capped positions

### DIFF
--- a/contracts/margin/external/ERC20/ERC20CappedLong.sol
+++ b/contracts/margin/external/ERC20/ERC20CappedLong.sol
@@ -20,6 +20,7 @@ pragma solidity 0.4.24;
 pragma experimental "v0.5.0";
 
 import { SafeMath } from "openzeppelin-solidity/contracts/math/SafeMath.sol";
+import { DetailedERC20 } from "openzeppelin-solidity/contracts/token/ERC20/DetailedERC20.sol";
 import { ERC20CappedPosition } from "./ERC20CappedPosition.sol";
 import { ERC20Long } from "./ERC20Long.sol";
 
@@ -33,7 +34,8 @@ import { ERC20Long } from "./ERC20Long.sol";
  */
 contract ERC20CappedLong is
     ERC20Long,
-    ERC20CappedPosition
+    ERC20CappedPosition,
+    DetailedERC20
 {
     using SafeMath for uint256;
 
@@ -46,7 +48,10 @@ contract ERC20CappedLong is
         address[] trustedRecipients,
         address[] trustedWithdrawers,
         address[] trustedLateClosers,
-        uint256 cap
+        uint256 cap,
+        string name,
+        string symbol,
+        uint8 decimals
     )
         public
         ERC20Long(
@@ -59,6 +64,11 @@ contract ERC20CappedLong is
         ERC20CappedPosition(
             trustedLateClosers,
             cap
+        )
+        DetailedERC20(
+            name,
+            symbol,
+            decimals
         )
     {
     }

--- a/contracts/margin/external/ERC20/ERC20CappedShort.sol
+++ b/contracts/margin/external/ERC20/ERC20CappedShort.sol
@@ -20,6 +20,7 @@ pragma solidity 0.4.24;
 pragma experimental "v0.5.0";
 
 import { SafeMath } from "openzeppelin-solidity/contracts/math/SafeMath.sol";
+import { DetailedERC20 } from "openzeppelin-solidity/contracts/token/ERC20/DetailedERC20.sol";
 import { ERC20CappedPosition } from "./ERC20CappedPosition.sol";
 import { ERC20Short } from "./ERC20Short.sol";
 
@@ -33,7 +34,8 @@ import { ERC20Short } from "./ERC20Short.sol";
  */
 contract ERC20CappedShort is
     ERC20Short,
-    ERC20CappedPosition
+    ERC20CappedPosition,
+    DetailedERC20
 {
     using SafeMath for uint256;
 
@@ -46,7 +48,10 @@ contract ERC20CappedShort is
         address[] trustedRecipients,
         address[] trustedWithdrawers,
         address[] trustedLateClosers,
-        uint256 cap
+        uint256 cap,
+        string name,
+        string symbol,
+        uint8 decimals
     )
         public
         ERC20Short(
@@ -59,6 +64,11 @@ contract ERC20CappedShort is
         ERC20CappedPosition(
             trustedLateClosers,
             cap
+        )
+        DetailedERC20(
+            name,
+            symbol,
+            decimals
         )
     {
     }

--- a/test/tests/margin/external/erc20/TestERC20CappedPosition.js
+++ b/test/tests/margin/external/erc20/TestERC20CappedPosition.js
@@ -26,6 +26,9 @@ contract('ERC20CappedPosition', accounts => {
 
   let POSITIONS = {
     LONG: {
+      NAME: "LONG_NAME",
+      SYMBOL: "LONG_SYMBOL",
+      DECIMALS: 222,
       TOKEN_CONTRACT: null,
       TX: null,
       ID: null,
@@ -35,6 +38,9 @@ contract('ERC20CappedPosition', accounts => {
       SALT: 0
     },
     SHORT: {
+      NAME: "SHORT_NAME",
+      SYMBOL: "SHORT_SYMBOL",
+      DECIMALS: 111,
       TOKEN_CONTRACT: null,
       TX: null,
       ID: null,
@@ -104,6 +110,9 @@ contract('ERC20CappedPosition', accounts => {
         POSITIONS.LONG.TRUSTED_WITHDRAWERS,
         [TRUSTED_LATE_CLOSER],
         POSITIONS.LONG.NUM_TOKENS.times(multiplier),
+        POSITIONS.LONG.NAME,
+        POSITIONS.LONG.SYMBOL,
+        POSITIONS.LONG.DECIMALS,
       ),
       ERC20CappedShort.new(
         POSITIONS.SHORT.ID,
@@ -113,6 +122,9 @@ contract('ERC20CappedPosition', accounts => {
         POSITIONS.LONG.TRUSTED_WITHDRAWERS,
         [TRUSTED_LATE_CLOSER],
         POSITIONS.SHORT.NUM_TOKENS.times(multiplier),
+        POSITIONS.SHORT.NAME,
+        POSITIONS.SHORT.SYMBOL,
+        POSITIONS.SHORT.DECIMALS,
       )
     ]);
   }
@@ -140,6 +152,9 @@ contract('ERC20CappedPosition', accounts => {
     const trustedLateCloser = accounts[7];
     const initialTokenHolder = accounts[6];
     const untrustedAccount = accounts[5];
+    const givenName = 'givenName';
+    const givenSymbol = 'givenSymbol';
+    const givenDecimals = 99;
 
     it('sets constants correctly for short', async () => {
       const tokenContract = await ERC20CappedShort.new(
@@ -149,10 +164,16 @@ contract('ERC20CappedPosition', accounts => {
         [trustedRecipient],
         [trustedWithdrawer],
         [trustedLateCloser],
-        tokenCap
+        tokenCap,
+        givenName,
+        givenSymbol,
+        givenDecimals,
       );
       const [
         supply,
+        name,
+        symbol,
+        decimals,
         cap,
         pid,
         ith,
@@ -166,6 +187,9 @@ contract('ERC20CappedPosition', accounts => {
         ua_is_tw,
       ] = await Promise.all([
         tokenContract.totalSupply.call(),
+        tokenContract.name.call(),
+        tokenContract.symbol.call(),
+        tokenContract.decimals.call(),
         tokenContract.tokenCap.call(),
         tokenContract.POSITION_ID.call(),
         tokenContract.INITIAL_TOKEN_HOLDER.call(),
@@ -179,6 +203,9 @@ contract('ERC20CappedPosition', accounts => {
         tokenContract.TRUSTED_WITHDRAWERS.call(untrustedAccount),
       ]);
       expect(supply).to.be.bignumber.eq(0);
+      expect(name).to.be.eq(givenName);
+      expect(symbol).to.be.eq(givenSymbol);
+      expect(decimals).to.be.bignumber.eq(givenDecimals);
       expect(cap).to.be.bignumber.eq(tokenCap);
       expect(pid).to.be.bignumber.eq(positionId);
       expect(ith).to.be.bignumber.eq(initialTokenHolder);
@@ -193,17 +220,23 @@ contract('ERC20CappedPosition', accounts => {
     });
 
     it('sets constants correctly for long', async () => {
-      const tokenContract = await ERC20CappedShort.new(
+      const tokenContract = await ERC20CappedLong.new(
         positionId,
         dydxMargin.address,
         initialTokenHolder,
         [trustedRecipient],
         [trustedWithdrawer],
         [trustedLateCloser],
-        tokenCap
+        tokenCap,
+        givenName,
+        givenSymbol,
+        givenDecimals,
       );
       const [
         supply,
+        name,
+        symbol,
+        decimals,
         cap,
         pid,
         ith,
@@ -217,6 +250,9 @@ contract('ERC20CappedPosition', accounts => {
         ua_is_tw,
       ] = await Promise.all([
         tokenContract.totalSupply.call(),
+        tokenContract.name.call(),
+        tokenContract.symbol.call(),
+        tokenContract.decimals.call(),
         tokenContract.tokenCap.call(),
         tokenContract.POSITION_ID.call(),
         tokenContract.INITIAL_TOKEN_HOLDER.call(),
@@ -230,6 +266,9 @@ contract('ERC20CappedPosition', accounts => {
         tokenContract.TRUSTED_WITHDRAWERS.call(untrustedAccount),
       ]);
       expect(supply).to.be.bignumber.eq(0);
+      expect(name).to.be.eq(givenName);
+      expect(symbol).to.be.eq(givenSymbol);
+      expect(decimals).to.be.bignumber.eq(givenDecimals);
       expect(cap).to.be.bignumber.eq(tokenCap);
       expect(pid).to.be.bignumber.eq(positionId);
       expect(ith).to.be.bignumber.eq(initialTokenHolder);


### PR DESCRIPTION
https://solidity.readthedocs.io/en/v0.4.24/contracts.html#multiple-inheritance-and-linearization

Explanation on how this overrides the name/symbol/decimal functions on ERC20Long and ERC20Short

Fixes #490